### PR TITLE
fix: Log debug level at service level

### DIFF
--- a/src/gallia/transports/can.py
+++ b/src/gallia/transports/can.py
@@ -163,7 +163,7 @@ class ISOTPTransport(BaseTransport, scheme="isotp", spec=isotp_spec):
         timeout: Optional[float] = None,
         tags: Optional[list[str]] = None,
     ) -> int:
-        self.logger.log_write(data.hex(), tags=tags)
+        self.logger.log_trace(data.hex(), tags=tags)
         loop = asyncio.get_running_loop()
         await asyncio.wait_for(loop.sock_sendall(self._sock, data), timeout)
         return len(data)
@@ -182,7 +182,7 @@ class ISOTPTransport(BaseTransport, scheme="isotp", spec=isotp_spec):
             if e.errno == errno.EILSEQ:
                 raise BrokenPipeError(f"invalid consecutive frame numbers: {e}") from e
             raise e
-        self.logger.log_read(data.hex(), tags=tags)
+        self.logger.log_trace(data.hex(), tags=tags)
         return data
 
     async def sendto(
@@ -376,9 +376,9 @@ class RawCANTransport(BaseTransport, scheme="can-raw", spec=spec_can_raw):
             check=True,
         )
         if self.args["is_extended"]:
-            self.logger.log_write(f"{dst:08x}#{data.hex()}", tags=tags)
+            self.logger.log_trace(f"{dst:08x}#{data.hex()}", tags=tags)
         else:
-            self.logger.log_write(f"{dst:03x}#{data.hex()}", tags=tags)
+            self.logger.log_trace(f"{dst:03x}#{data.hex()}", tags=tags)
 
         loop = asyncio.get_running_loop()
         await asyncio.wait_for(loop.sock_sendall(self._sock, msg.pack()), timeout)
@@ -394,11 +394,11 @@ class RawCANTransport(BaseTransport, scheme="can-raw", spec=spec_can_raw):
         msg = CANMessage.unpack(can_frame)
 
         if msg.is_extended_id:
-            self.logger.log_read(
+            self.logger.log_trace(
                 f"{msg.arbitration_id:08x}#{msg.data.hex()}", tags=tags
             )
         else:
-            self.logger.log_read(
+            self.logger.log_trace(
                 f"{msg.arbitration_id:03x}#{msg.data.hex()}", tags=tags
             )
         return msg.arbitration_id, msg.data

--- a/src/gallia/transports/doip.py
+++ b/src/gallia/transports/doip.py
@@ -544,7 +544,7 @@ class DoIPTransport(BaseTransport, scheme="doip", spec=doip_spec):
         assert self.connection is not None, assertion_str
 
         data = await asyncio.wait_for(self.connection.read_diag_request(), timeout)
-        self.logger.log_read(data.hex(), tags)
+        self.logger.log_trace(data.hex(), tags)
         return data
 
     async def write(
@@ -556,7 +556,7 @@ class DoIPTransport(BaseTransport, scheme="doip", spec=doip_spec):
         assert self.connection is not None, assertion_str
 
         await asyncio.wait_for(self.connection.write_diag_request(data), timeout)
-        self.logger.log_write(data.hex(), tags)
+        self.logger.log_trace(data.hex(), tags)
         return len(data)
 
     async def sendto(
@@ -578,7 +578,7 @@ class DoIPTransport(BaseTransport, scheme="doip", spec=doip_spec):
             SourceAddress=self.args["src_addr"], TargetAddress=dst, UserData=data
         )
         await asyncio.wait_for(self.connection.write_request_raw(hdr, payload), timeout)
-        self.logger.log_write(f"{dst:x}#{data.hex()}", tags)
+        self.logger.log_trace(f"{dst:x}#{data.hex()}", tags)
 
         return len(data)
 
@@ -590,7 +590,7 @@ class DoIPTransport(BaseTransport, scheme="doip", spec=doip_spec):
         _, payload = await asyncio.wait_for(
             self.connection.read_diag_request_raw(), timeout
         )
-        self.logger.log_read(
+        self.logger.log_trace(
             f"{payload.SourceAddress:x}#{payload.UserData.hex()}", tags
         )
         return payload.SourceAddress, payload.UserData

--- a/src/gallia/transports/tcp.py
+++ b/src/gallia/transports/tcp.py
@@ -50,7 +50,7 @@ class TCPTransport(BaseTransport, scheme="tcp", spec=tcp_spec):
     ) -> int:
         assert self.reader is not None and self.writer is not None, assertion_str
 
-        self.logger.log_write(data.hex(), tags=tags)
+        self.logger.log_trace(data.hex(), tags=tags)
         self.writer.write(data)
         await asyncio.wait_for(self.writer.drain(), timeout)
         return len(data)
@@ -63,7 +63,7 @@ class TCPTransport(BaseTransport, scheme="tcp", spec=tcp_spec):
         assert self.reader is not None and self.writer is not None, assertion_str
 
         data = await asyncio.wait_for(self.reader.read(self.BUFSIZE), timeout)
-        self.logger.log_read(data.hex(), tags=tags)
+        self.logger.log_trace(data.hex(), tags=tags)
         return data
 
     async def sendto(
@@ -93,7 +93,7 @@ class TCPLineSepTransport(TCPTransport, scheme="tcp-lines", spec=tcp_spec):
         assert self.reader is not None and self.writer is not None, assertion_str
 
         d = binascii.hexlify(data)
-        self.logger.log_write(data.hex(), tags=tags)
+        self.logger.log_trace(data.hex(), tags=tags)
         self.writer.write(d + b"\n")
         await asyncio.wait_for(self.writer.drain(), timeout)
         return len(data)
@@ -107,5 +107,5 @@ class TCPLineSepTransport(TCPTransport, scheme="tcp-lines", spec=tcp_spec):
 
         data = await asyncio.wait_for(self.reader.readline(), timeout)
         d = data.decode().strip()
-        self.logger.log_read(d, tags=tags)
+        self.logger.log_trace(d, tags=tags)
         return binascii.unhexlify(d)

--- a/src/gallia/uds/core/client.py
+++ b/src/gallia/uds/core/client.py
@@ -117,6 +117,8 @@ class UDSClient:
             else:
                 # We reach this code here once all response pending
                 # and similar busy stuff is resolved.
+                self.logger.log_write(request.pdu.hex(), tags=config.tags)
+                self.logger.log_read(resp.pdu.hex(), tags=config.tags)
                 return resp
 
         self.logger.log_debug(f"{request} failed after retry loop")

--- a/src/gallia/uds/ecu.py
+++ b/src/gallia/uds/ecu.py
@@ -45,7 +45,6 @@ class ECU(UDSClient):
     ) -> None:
 
         super().__init__(transport, timeout, max_retry)
-        self.logger = Logger(component="ecu", flush=True)
         self.power_supply = power_supply
         self.state = ECUState()
         self.db_handler: Optional[DBHandler] = None


### PR DESCRIPTION
Currently we rely on UDS traffic logged at the transport level. That's
an unfortunate layer violation and it is better to log this at
debug level at the service level instead.

Transports are degraded to log_trace(), since these data is only needed
when debugging is needed.