### PR TITLE
feat: Make missing vendor a hard error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,10 +47,6 @@ sphinx-rtd-theme = "^1.0.0"
 "discover-xcp" = "gallia.udscan.scanner.find_xcp:main"
 "cursed-hr" = "gallia.cursed_hr.cursed_hr:main"
 
-[tool.poetry.plugins]
-[tool.poetry.plugins."gallia_ecus"]
-"default" = "gallia.udscan.core:ECU"
-
 [tool.poetry.plugins."gallia_scanners"]
 "discover-can-ids" = "gallia.udscan.scanner.find_can_ids:FindCanIDsScanner"
 "discover-iso-tp-addr" = "gallia.udscan.scanner.find_iso_tp_addr:FindISOTPAddrScanner"

--- a/src/gallia/udscan/core.py
+++ b/src/gallia/udscan/core.py
@@ -356,15 +356,17 @@ class UDSScanner(Scanner):
         )
 
     def load_ecu(self, vendor: str) -> type[ECU]:
-        for entry_point in entry_points()["gallia_ecus"]:
-            if vendor == entry_point.name:
-                self.logger.log_debug(f"Loading OEM-ECU {entry_point}")
-                return entry_point.load()
+        if vendor == "default":
+            return ECU
 
-        self.logger.log_warning(
-            f"Could not find ECU for OEM '{vendor}', using non-OEM-specific ECU"
-        )
-        return ECU
+        eps = entry_points()
+        if "gallia_ecus" in eps:
+            for entry_point in eps["gallia_ecus"]:
+                if vendor == entry_point.name:
+                    self.logger.log_debug(f"Loading OEM-ECU {entry_point}")
+                    return entry_point.load()
+
+        raise ValueError(f"no such OEM: '{vendor}'")
 
     async def _tester_present_worker(self, interval: int) -> None:
         assert self.transport


### PR DESCRIPTION
Make the cli fail hard in case an invalid vendor is supplied. Otherwise
it might cause wrong scan results. Further, the default ECU is loaded
directly and not as an entry point. This gives better tracebacks.