### PR TITLE
ci: Trigger ci also on dependency updates

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -8,6 +8,8 @@ on:
     - master
   pull_request:
     paths:
+    - 'pyproject.toml'
+    - 'poetry.lock'
     - '.github/**'
     - 'src/**'
     - 'tests/**'


### PR DESCRIPTION
I missed this one; we want checks when `dependabot` spams.