### PR TITLE
fix(db): correct index declaration

### DIFF
--- a/src/gallia/db/db_handler.py
+++ b/src/gallia/db/db_handler.py
@@ -63,7 +63,6 @@ CREATE TABLE IF NOT EXISTS scan_run (
   properties_post json check(properties_post is null or json_valid(properties_post)),
   meta int references run_meta(id) on update cascade on delete cascade
 );
-CREATE INDEX IF NOT EXISTS ix_scan_run_request_pdu ON scan_run(request_pdu);
 CREATE TABLE IF NOT EXISTS discovery_result (
   id integer primary key,
   run int not null references discovery_run(id) on update cascade on delete cascade,
@@ -84,6 +83,7 @@ CREATE TABLE IF NOT EXISTS scan_result (
   response_data json check(response_data is null or json_valid(response_data)),
   exception text
 );
+CREATE INDEX IF NOT EXISTS ix_scan_run_request_pdu ON scan_run(request_pdu);
 
 INSERT OR IGNORE INTO version VALUES('main', '{schema_version}');
 """


### PR DESCRIPTION
Currently the initialization of a new database fails, because the index declaration is wrong.