### PR TITLE
fix(db): Improve stability for concurrent operation

### DIFF
--- a/src/gallia/udscan/core.py
+++ b/src/gallia/udscan/core.py
@@ -130,15 +130,16 @@ class GalliaBase(ABC):
             exit_code = se.code
             raise
         finally:
-            if self.db_handler is not None:
-                try:
-                    await self.db_handler.complete_run_meta(
-                        datetime.now(timezone.utc).astimezone(), exit_code
-                    )
-                except Exception as e:
-                    self.logger.log_warning(
-                        f"Could not write the run meta to the database: {repr(e)}"
-                    )
+            if self.db_handler is not None and self.db_handler.connection is not None:
+                if self.db_handler.meta is not None:
+                    try:
+                        await self.db_handler.complete_run_meta(
+                            datetime.now(timezone.utc).astimezone(), exit_code
+                        )
+                    except Exception as e:
+                        self.logger.log_warning(
+                            f"Could not write the run meta to the database: {repr(e)}"
+                        )
 
                 try:
                     await self.db_handler.disconnect()


### PR DESCRIPTION
Fixes #97 

Tested with up to 16 concurrent scans on up to 16 virtual ECUs.
However, due to computational limits, this needs further testing in a real setup.
Perhaps the busy timeout might have to be increased, depending on the actual setup.