### PR TITLE
fix(db): Improve stability for concurrent operation

### DIFF
--- a/src/gallia/udscan/core.py
+++ b/src/gallia/udscan/core.py
@@ -130,21 +130,22 @@ class GalliaBase(ABC):
             exit_code = se.code
             raise
         finally:
-            if self.db_handler is not None:
-                try:
-                    await self.db_handler.complete_run_meta(
-                        datetime.now(timezone.utc).astimezone(), exit_code
-                    )
-                except Exception as e:
-                    self.logger.log_warning(
-                        f"Could not write the run meta to the database: {repr(e)}"
-                    )
+            if self.db_handler is not None and self.db_handler.connection is not None:
+                if self.db_handler.meta is not None:
+                    try:
+                        await self.db_handler.complete_run_meta(
+                            datetime.now(timezone.utc).astimezone(), exit_code
+                        )
+                    except Exception as e:
+                        self.logger.log_warning(
+                            f"Could not write the run meta to the database: {repr(e)}"
+                        )
 
                 try:
                     await self.db_handler.disconnect()
                 except Exception as e:
-                    self.logger.log_debug(
-                        f"Could not close the database connection {repr(e)}"
+                    self.logger.log_error(
+                        f"Could not close the database connection properly: {repr(e)}"
                     )
 
     def _add_class_parser(self) -> None:


### PR DESCRIPTION
Fixes #98 

- runs frequent database writes (i.e. inserts into scan_result) in background to avoid long waiting times
- only immutable values are passed to the task to ensure that future changes don't affect waiting tasks
- timed out inserts are retried in a loop (perhaps better suited than "infinitely" long timeouts), however could lead to a non-terminating program in case a different error case with the same error type (aiosqlite.OperationalError) is raised.
- failed attempts to disconnect are now logged with error priority to make sure, the user becomes aware of it. Additionally, the close statement is now always executed, and the program should therefore be able to terminate in any case.