### PR TITLE
refactor: Change .terminate() to .close()

### DIFF
--- a/src/gallia/transports/base.py
+++ b/src/gallia/transports/base.py
@@ -137,7 +137,7 @@ class BaseTransport(ABC):
         ...
 
     @abstractmethod
-    async def terminate(self) -> None:
+    async def close(self) -> None:
         ...
 
     @abstractmethod

--- a/src/gallia/transports/can.py
+++ b/src/gallia/transports/can.py
@@ -199,7 +199,7 @@ class ISOTPTransport(BaseTransport, scheme="isotp", spec=isotp_spec):
     ) -> tuple[int, bytes]:
         raise NotImplementedError()
 
-    async def terminate(self) -> None:
+    async def close(self) -> None:
         pass
 
     async def reconnect(self, timeout: Optional[float] = None) -> None:
@@ -403,7 +403,7 @@ class RawCANTransport(BaseTransport, scheme="can-raw", spec=spec_can_raw):
             )
         return msg.arbitration_id, msg.data
 
-    async def terminate(self) -> None:
+    async def close(self) -> None:
         pass
 
     async def reconnect(self, timeout: Optional[float] = None) -> None:

--- a/src/gallia/transports/doip.py
+++ b/src/gallia/transports/doip.py
@@ -530,10 +530,10 @@ class DoIPTransport(BaseTransport, scheme="doip", spec=doip_spec):
         assert self.target.hostname is not None, "bug: no hostname"
 
         async with self.mutex:
-            await self.terminate()
+            await self.close()
             await asyncio.wait_for(self._connect(), timeout)
 
-    async def terminate(self) -> None:
+    async def close(self) -> None:
         assert self.connection is not None, assertion_str
 
         await self.connection.close()

--- a/src/gallia/transports/tcp.py
+++ b/src/gallia/transports/tcp.py
@@ -31,10 +31,10 @@ class TCPTransport(BaseTransport, scheme="tcp", spec=tcp_spec):
         )
 
     async def reconnect(self, timeout: Optional[float] = None) -> None:
-        await self.terminate()
+        await self.close()
         await self.connect(timeout)
 
-    async def terminate(self) -> None:
+    async def close(self) -> None:
         assert self.reader is not None and self.writer is not None, assertion_str
 
         self.writer.close()

--- a/src/gallia/udscan/core.py
+++ b/src/gallia/udscan/core.py
@@ -290,7 +290,7 @@ class Scanner(GalliaBase):
 
     async def teardown(self, args: Namespace) -> None:
         if self.transport:
-            await self.transport.terminate()
+            await self.transport.close()
         if self.dumpcap:
             await self.dumpcap.stop()
 


### PR DESCRIPTION
This matches the socket API better and does not cause confusion.
