### PR TITLE
fix(cursed-hr): flush file content

### DIFF
--- a/src/gallia/cursed_hr/cursed_hr.py
+++ b/src/gallia/cursed_hr/cursed_hr.py
@@ -261,6 +261,8 @@ class CursedHR:
             else:
                 file = self.in_file.open("rb")
 
+            file.flush()
+
             return file  # type: ignore
         except Exception as e:
             raise ValueError("Unsupported file format") from e


### PR DESCRIPTION
Otherwise for some files, an error is raised when trying to mmap the, then empty, file.