### PR TITLE
fix(discovery): Better error message for missing targets

### DIFF
--- a/src/gallia/udscan/core.py
+++ b/src/gallia/udscan/core.py
@@ -280,6 +280,9 @@ class Scanner(GalliaBase):
         elif args.power_cycle is not None:
             self.parser.error("--power-cycle needs --power-supply")
 
+        if args.target is None:
+            self.parser.error("--target required")
+
         # Start dumpcap as the first subprocess; otherwise network
         # traffic might be missing.
         if args.dumpcap:

--- a/src/gallia/udscan/scanner/find_can_ids.py
+++ b/src/gallia/udscan/scanner/find_can_ids.py
@@ -50,7 +50,7 @@ class FindCanIDsScanner(DiscoveryScanner):
         )
 
     async def setup(self, args: Namespace) -> None:
-        if not args.target.scheme == RawCANTransport.SCHEME:
+        if args.target is not None and not args.target.scheme == RawCANTransport.SCHEME:
             self.logger.log_error(
                 f"Unsupported transport schema {args.target.scheme}; must be can-raw!"
             )


### PR DESCRIPTION
Currently only a cryptic error message is shown to the user, which is not helpful.