### PR TITLE
fix(vecu): set TesterPresent subfunctions to zero subfunction

### DIFF
--- a/src/gallia/uds/core/server.py
+++ b/src/gallia/uds/core/server.py
@@ -478,7 +478,9 @@ class RandomUDSServer(UDSServer):
                 if self._is_sub_function_service(supported_service):
                     # For SecurityAccess there are always two consecutive sub functions, the uneven one for RequestSeed,
                     # the even one (+1) for SendKey
-                    if supported_service == UDSIsoServices.DiagnosticSessionControl:
+                    if supported_service == UDSIsoServices.TesterPresent:
+                        supported_sub_functions = [0]
+                    elif supported_service == UDSIsoServices.DiagnosticSessionControl:
                         supported_sub_functions = sorted(session_specific_transitions)
                     elif supported_service == UDSIsoServices.SecurityAccess:
                         supported_sub_functions_tmp = list(


### PR DESCRIPTION
Currently, the set of subfunctions is random for the service TesterPresent, which does not make sense, as the standard states clearly, that this service has no subfunction besides the so called "zeroSubFunction".