### PR TITLE
 fix: Deny all quotes in -T

### DIFF
--- a/bin/penrun
+++ b/bin/penrun
@@ -321,6 +321,12 @@ main() {
 	done
 	shift $((OPTIND - 1))
 
+	if [[ -n "$template" ]]; then
+		if [[ "$template" =~ .*\" || "$template" =~ .*\' ]]; then
+			die "-T must not contain any quotes!"
+		fi
+	fi
+
 	local cmds
 	if [[ ! -t 0 ]]; then
 		mapfile -t cmds </dev/stdin

--- a/bin/penrun
+++ b/bin/penrun
@@ -76,16 +76,16 @@ search_and_source_config() {
 
 lock_or_wait() {
 	if [[ -n "${PENRUN_LOCK-}" ]]; then
-                mkdir -p "$(dirname "${PENRUN_LOCK}")" && touch "${PENRUN_LOCK}" 2> /dev/null
-                exec 87<"${PENRUN_LOCK}"
+		mkdir -p "$(dirname "${PENRUN_LOCK}")" && touch "${PENRUN_LOCK}" 2>/dev/null
+		exec 87<"${PENRUN_LOCK}"
 
-                if ! flock -n 87; then
-                        echo "Could not aquire lock ${PENRUN_LOCK}"
-                        echo "Waiting ..."
-                        flock 87 || die "Lock cannot be aquired"
-                        echo "... aquired lock"
-                fi
-    	fi
+		if ! flock -n 87; then
+			echo "Could not aquire lock ${PENRUN_LOCK}"
+			echo "Waiting ..."
+			flock 87 || die "Lock cannot be aquired"
+			echo "... aquired lock"
+		fi
+	fi
 }
 
 # $1: path


### PR DESCRIPTION
Due to the bash quoting concepts it is not trivially possible to support
quotes in template strings. Since penrun is deprecated and will be
replaced by a python implementation in v1.1.0 let's deny qotes in -T in
order to not confuse the user.