### PR TITLE
feat(cli): Unified output

### DIFF
--- a/src/gallia/db/db_handler.py
+++ b/src/gallia/db/db_handler.py
@@ -10,6 +10,7 @@ import aiosqlite
 from gallia.uds.core import service
 from gallia.uds.core.utils import bytes_repr as bytes_repr_
 from gallia.penlog import Logger
+from gallia.utils import g_repr
 
 
 def bytes_repr(data: bytes) -> str:
@@ -152,7 +153,7 @@ class DBHandler:
             try:
                 await task
             except Exception as e:
-                self.logger.log_error(f"Inside task: {repr(e)}")
+                self.logger.log_error(f"Inside task: {g_repr(e)}")
 
         try:
             await self.connection.commit()

--- a/src/gallia/penlab.py
+++ b/src/gallia/penlab.py
@@ -19,7 +19,7 @@ from opennetzteil import Netzteil
 from gallia.penlog import Logger
 from gallia.transports.base import TargetURI
 from gallia.transports.can import ISOTPTransport, RawCANTransport
-from gallia.utils import split_host_port
+from gallia.utils import split_host_port, g_repr
 
 
 class PowerSupplyURI(TargetURI):
@@ -133,7 +133,7 @@ class Dumpcap:
             )
             await asyncio.sleep(0.2)
         except Exception as e:
-            logger.log_error(f"Could not start dumpcap: ({e.__class__.__name__}) {e}")
+            logger.log_error(f"Could not start dumpcap: ({g_repr(e)})")
             raise
 
         if proc.returncode:

--- a/src/gallia/services/xcp.py
+++ b/src/gallia/services/xcp.py
@@ -20,7 +20,7 @@ class XCPService:
         t = timeout if timeout else self.timeout
         resp = await self.transport.request(data, t)
         header = pyxcp.types.Response.parse(resp)
-        self.logger.log_info(str(header))
+        self.logger.log_info(header)
         if int(header.type) != 255:
             raise ValueError(
                 f"Unknown response type: {header.type}, maybe no XCP packet?"
@@ -34,20 +34,20 @@ class XCPService:
         tmp = pyxcp.types.ConnectResponsePartial.parse(resp)
         self.byte_order = tmp.commModeBasic.byteOrder
         tmp = pyxcp.types.ConnectResponse.parse(resp, byteOrder=self.byte_order)
-        self.logger.log_info(str(tmp))
+        self.logger.log_info(tmp)
         self.logger.log_summary("XCP CONNECT -> OK")
 
     async def disconnect(self) -> None:
         self.logger.log_info("XCP DISCONNECT")
         resp = await self.request(bytes([0xFE, 0x00]))
-        self.logger.log_info(str(resp))
+        self.logger.log_info(resp)
         self.logger.log_summary("XCP DISCONNECT -> OK")
 
     async def get_status(self) -> None:
         self.logger.log_info("XCP GET_STATUS")
         resp = await self.request(bytes([0xFD]))
         tmp = pyxcp.types.GetStatusResponse.parse(resp, byteOrder=self.byte_order)
-        self.logger.log_info(str(tmp))
+        self.logger.log_info(tmp)
         self.logger.log_summary("XCP GET_STATUS -> OK")
 
     async def get_comm_mode_info(self) -> None:
@@ -57,18 +57,18 @@ class XCPService:
             resp,
             byteOrder=self.byte_order,
         )
-        self.logger.log_info(str(tmp))
+        self.logger.log_info(tmp)
         self.logger.log_summary("XCP GET_COMM_MODE_INFO -> OK")
 
     async def get_id(self, id_: int) -> None:
         self.logger.log_info(f"XCP GET_ID({id_})")
         resp = await self.request(bytes([0xFA, id_]))
         tmp = pyxcp.types.GetIDResponse.parse(resp, byteOrder=self.byte_order)
-        self.logger.log_info(str(tmp))
+        self.logger.log_info(tmp)
         self.logger.log_summary(f"XCP GET_ID({id_}) -> OK")
 
     async def upload(self, length: int) -> None:
         self.logger.log_info(f"XCP GET_UPLOAD({length}")
         resp = await self.request(bytes([0xF5, length]))
-        self.logger.log_info(str(resp))
+        self.logger.log_info(resp)
         self.logger.log_summary(f"XCP GET_UPLOAD({length} -> OK")

--- a/src/gallia/uds/core/client.py
+++ b/src/gallia/uds/core/client.py
@@ -71,7 +71,7 @@ class UDSClient:
                     request.pdu, timeout, config.tags
                 )
             except asyncio.TimeoutError as e:
-                self.logger.log_debug(f"{request} failed with: {type(e)}")
+                self.logger.log_debug(f"{request} failed with: {repr(e)}")
                 last_exception = MissingResponse(request, str(e))
                 await asyncio.sleep(wait_time)
                 continue

--- a/src/gallia/uds/core/utils.py
+++ b/src/gallia/uds/core/utils.py
@@ -88,15 +88,6 @@ def service_repr(service_id: int) -> str:
         return f"Unknown service {int_repr(service_id)}"
 
 
-def shorten(string: str, width: int = 16) -> str:
-    """Shorten a given string to a specified number of characters.
-    An ellipsis `…` as added if the string is truncated.
-    """
-    if len(string) <= width:
-        return string
-    return f"{string[:width - 1]}…"
-
-
 def uds_memory_parameters(
     memory_address: int, memory_size: int, address_and_length_fmt: Optional[int] = None
 ) -> tuple[int, bytes, bytes]:

--- a/src/gallia/uds/ecu.py
+++ b/src/gallia/uds/ecu.py
@@ -14,6 +14,7 @@ from gallia.uds.core.constants import DataIdentifier
 from gallia.uds.core.exception import ResponseException
 from gallia.uds.core.utils import from_bytes
 from gallia.uds.helpers import as_exception, raise_for_error
+from gallia.utils import g_repr
 
 
 class ECUState:
@@ -205,7 +206,9 @@ class ECU(UDSClient):
         """transmit_data splits the data to be sent in several blocks of size block_length,
         transfers all of them and concludes the transmission with RequestTransferExit"""
         if block_length > max_block_length:
-            self.logger.log_warning(f"Limiting block size to 0x{max_block_length:x}")
+            self.logger.log_warning(
+                f"Limiting block size to {g_repr(max_block_length)}"
+            )
             block_length = max_block_length
         # block_length includes the service identifier and block counter; payload must be smaller
         payload_size = block_length - 2
@@ -214,13 +217,13 @@ class ECU(UDSClient):
             counter += 1
             payload = data[i : i + payload_size]
             self.logger.log_debug(
-                f"Transferring block 0x{counter:02x} "
-                f"with payload size 0x{len(payload):x}"
+                f"Transferring block {g_repr(counter)} "
+                f"with payload size {g_repr(len(payload))}"
             )
             resp: service.UDSResponse = await self.transfer_data(
                 counter & 0xFF, payload, config=config
             )
-            raise_for_error(resp, f"Transmitting data failed at index 0x{i:x}")
+            raise_for_error(resp, f"Transmitting data failed at index {g_repr(i)}")
         resp = await self.request_transfer_exit(config=config)
         raise_for_error(resp)
 
@@ -250,7 +253,7 @@ class ECU(UDSClient):
             except OSError:
                 raise
             except Exception as e:
-                self.logger.log_debug(f"ECU not ready: {e.__class__.__name__} {e}")
+                self.logger.log_debug(f"ECU not ready: {g_repr(e)}")
         self.logger.log_info("ECU ready")
 
     async def update_state(
@@ -321,7 +324,9 @@ class ECU(UDSClient):
                         log_mode,
                     )
             except Exception as e:
-                self.logger.log_warning(f"Could not log messages to database: {e}")
+                self.logger.log_warning(
+                    f"Could not log messages to database: {g_repr(e)}"
+                )
 
             if response is not None:
                 await self.update_state(request, response)

--- a/src/gallia/udscan/core.py
+++ b/src/gallia/udscan/core.py
@@ -28,7 +28,7 @@ from gallia.transports.can import ISOTPTransport, RawCANTransport
 from gallia.transports.doip import DoIPTransport
 from gallia.transports.tcp import TCPLineSepTransport
 from gallia.uds.ecu import ECU
-from gallia.utils import camel_to_snake
+from gallia.utils import camel_to_snake, g_repr
 
 
 class ExitCodes(IntEnum):
@@ -265,9 +265,9 @@ class Scanner(GalliaBase, ABC):
                 await self.setup(args)
             except BrokenPipeError as e:
                 exit_code = ExitCodes.GENERIC_ERROR
-                self.logger.log_critical(str(e))
+                self.logger.log_critical(g_repr(e))
             except Exception as e:
-                self.logger.log_critical(f"setup failed: {e.__class__.__name__}: {e}")
+                self.logger.log_critical(f"setup failed: {g_repr(e)}")
                 sys.exit(ExitCodes.SETUP_FAILED)
 
             try:
@@ -275,15 +275,13 @@ class Scanner(GalliaBase, ABC):
                     await self.main(args)
                 except Exception as e:
                     exit_code = ExitCodes.GENERIC_ERROR
-                    self.logger.log_critical(str(e))
+                    self.logger.log_critical(g_repr(e))
                     traceback.print_exc()
             finally:
                 try:
                     await self.teardown(args)
                 except Exception as e:
-                    self.logger.log_critical(
-                        f"teardown failed: {e.__class__.__name__}: {e}"
-                    )
+                    self.logger.log_critical(f"teardown failed: {g_repr(e)}")
                     sys.exit(ExitCodes.TEARDOWN_FAILED)
             return exit_code
         except KeyboardInterrupt:
@@ -301,14 +299,14 @@ class Scanner(GalliaBase, ABC):
                         )
                     except Exception as e:
                         self.logger.log_warning(
-                            f"Could not write the run meta to the database: {repr(e)}"
+                            f"Could not write the run meta to the database: {g_repr(e)}"
                         )
 
                 try:
                     await self.db_handler.disconnect()
                 except Exception as e:
                     self.logger.log_error(
-                        f"Could not close the database connection properly: {repr(e)}"
+                        f"Could not close the database connection properly: {g_repr(e)}"
                     )
 
     def run(self) -> int:
@@ -478,7 +476,7 @@ class UDSScanner(Scanner):
                 self.logger.log_debug("tester present worker terminated")
                 break
             except Exception as e:
-                self.logger.log_debug(f"tester present got {type(e)}")
+                self.logger.log_debug(f"tester present got {g_repr(e)}")
                 # Wait until the stack recovers, but not for too long…
                 await asyncio.sleep(1)
 
@@ -516,7 +514,7 @@ class UDSScanner(Scanner):
                 self._apply_implicit_logging_setting()
             except Exception as e:
                 self.logger.log_warning(
-                    f"Could not write the scan run to the database: {repr(e)}"
+                    f"Could not write the scan run to the database: {g_repr(e)}"
                 )
 
         # Handles connecting to the target and waits
@@ -548,7 +546,7 @@ class UDSScanner(Scanner):
                 self._apply_implicit_logging_setting()
             except Exception as e:
                 self.logger.log_warning(
-                    f"Could not write the properties_pre to the database: {repr(e)}"
+                    f"Could not write the properties_pre to the database: {g_repr(e)}"
                 )
 
     async def teardown(self, args: Namespace) -> None:
@@ -572,7 +570,7 @@ class UDSScanner(Scanner):
                 )
             except Exception as e:
                 self.logger.log_warning(
-                    f"Could not write the scan run to the database: {repr(e)}"
+                    f"Could not write the scan run to the database: {g_repr(e)}"
                 )
 
         if self.tester_present_task:
@@ -592,5 +590,5 @@ class DiscoveryScanner(Scanner):
                 await self.db_handler.insert_discovery_run(args.target.url.scheme)
             except Exception as e:
                 self.logger.log_warning(
-                    f"Could not write the discovery run to the database: {repr(e)}"
+                    f"Could not write the discovery run to the database: {g_repr(e)}"
                 )

--- a/src/gallia/udscan/scanner/find_endpoints.py
+++ b/src/gallia/udscan/scanner/find_endpoints.py
@@ -10,6 +10,7 @@ from gallia.uds.core.service import (
 from gallia.uds.helpers import raise_for_mismatch
 from gallia.udscan.core import UDSScanner
 from gallia.udscan.utils import auto_int, write_ecu_url_list
+from gallia.utils import g_repr
 
 
 class FindEndpoints(UDSScanner):
@@ -48,7 +49,7 @@ class FindEndpoints(UDSScanner):
                 await self.db_handler.insert_discovery_run(args.target.url.scheme)
             except Exception as e:
                 self.logger.log_warning(
-                    f"Could not write the discovery run to the database: {repr(e)}"
+                    f"Could not write the discovery run to the database: {g_repr(e)}"
                 )
 
     async def main(self, args: Namespace) -> None:
@@ -57,7 +58,7 @@ class FindEndpoints(UDSScanner):
                 await self.db_handler.insert_discovery_run(args.target.url.scheme)
             except Exception as e:
                 self.logger.log_warning(
-                    f"Could not write the discovery run to the database: {repr(e)}"
+                    f"Could not write the discovery run to the database: {g_repr(e)}"
                 )
 
         assert self.transport is not None

--- a/src/gallia/udscan/scanner/scan_memory_functions.py
+++ b/src/gallia/udscan/scanner/scan_memory_functions.py
@@ -9,6 +9,7 @@ from gallia.uds.core.service import NegativeResponse
 from gallia.uds.core.utils import uds_memory_parameters
 from gallia.udscan.core import UDSScanner
 from gallia.udscan.utils import auto_int, check_and_set_session
+from gallia.utils import g_repr
 
 
 class ScanWriteDataByAddress(UDSScanner):
@@ -80,8 +81,8 @@ class ScanWriteDataByAddress(UDSScanner):
                 # Check session and try to recover from wrong session (max 3 times), else skip session
                 if not await check_and_set_session(self.ecu, args.session):
                     self.logger.log_error(
-                        f"Aborting scan on session 0x{args.session:02x}; "
-                        + f"current memory address was 0x{addr:0x}"
+                        f"Aborting scan on session {g_repr(args.session)}; "
+                        + f"current memory address was {g_repr(addr)}"
                     )
                     sys.exit(1)
 
@@ -90,13 +91,13 @@ class ScanWriteDataByAddress(UDSScanner):
                     pdu, config=UDSRequestConfig(tags=["ANALYZE"])
                 )
             except asyncio.TimeoutError:
-                self.logger.log_summary(f"Address 0x{addr_bytes.hex()}: timeout")
+                self.logger.log_summary(f"Address {g_repr(addr)}: timeout")
                 continue
 
             if isinstance(resp, NegativeResponse):
                 if resp.response_code is UDSErrorCodes.requestOutOfRange:
-                    self.logger.log_info(f"Address 0x{addr_bytes.hex()}: {resp}")
+                    self.logger.log_info(f"Address {g_repr(addr)}: {resp}")
                 else:
-                    self.logger.log_summary(f"Address 0x{addr_bytes.hex()}: {resp}")
+                    self.logger.log_summary(f"Address {g_repr(addr)}: {resp}")
             else:
-                self.logger.log_summary(f"Address 0x{addr_bytes.hex()}: {resp}")
+                self.logger.log_summary(f"Address {g_repr(addr)}: {resp}")

--- a/src/gallia/udscan/scanner/scan_sa_dump_seeds.py
+++ b/src/gallia/udscan/scanner/scan_sa_dump_seeds.py
@@ -13,6 +13,7 @@ from gallia.uds.core.client import UDSRequestConfig
 from gallia.uds.core.service import NegativeResponse
 from gallia.udscan.core import UDSScanner
 from gallia.udscan.utils import auto_int, check_and_set_session
+from gallia.utils import g_repr
 
 
 class SaDumpSeeds(UDSScanner):
@@ -94,7 +95,7 @@ class SaDumpSeeds(UDSScanner):
             self.logger.log_debug(f"Key was rejected: {resp}")
             return False
         self.logger.log_summary(
-            f'Unlocked SA level 0x{level:02x} with key "{key.hex()}"! resp: {resp}'
+            f'Unlocked SA level {g_repr(level)} with key "{key.hex()}"! resp: {resp}'
         )
         return True
 
@@ -115,7 +116,7 @@ class SaDumpSeeds(UDSScanner):
 
     async def main(self, args: Namespace) -> None:
         session = args.session
-        self.logger.log_info(f"scanning in session: {session:02x}")
+        self.logger.log_info(f"scanning in session: {g_repr(session)}")
 
         resp = await self.ecu.set_session(session)
         if isinstance(resp, NegativeResponse):
@@ -140,7 +141,7 @@ class SaDumpSeeds(UDSScanner):
             if args.check_session or reset:
                 if not await check_and_set_session(self.ecu, args.session):
                     self.logger.log_error(
-                        f"ECU persistently lost session {args.session}"
+                        f"ECU persistently lost session {g_repr(args.session)}"
                     )
                     sys.exit(1)
 
@@ -152,7 +153,7 @@ class SaDumpSeeds(UDSScanner):
                 self.logger.log_error("Timeout while requesting seed")
                 continue
             except Exception as e:
-                self.logger.log_critical(f"Error while requesting seed: {e}")
+                self.logger.log_critical(f"Error while requesting seed: {g_repr(e)}")
                 sys.exit(1)
 
             if seed is None:
@@ -173,7 +174,7 @@ class SaDumpSeeds(UDSScanner):
                     self.logger.log_warning("Timeout while sending key")
                     continue
                 except Exception as e:
-                    self.logger.log_critical(f"Error while sending key: {e}")
+                    self.logger.log_critical(f"Error while sending key: {g_repr(e)}")
                     sys.exit(1)
 
             runs_since_last_reset += 1

--- a/src/gallia/udscan/scanner/scan_sessions.py
+++ b/src/gallia/udscan/scanner/scan_sessions.py
@@ -12,6 +12,7 @@ from gallia.uds.core.service import (
 )
 from gallia.udscan.core import UDSScanner
 from gallia.udscan.utils import auto_int
+from gallia.utils import g_repr
 
 
 class IterateSessions(UDSScanner):
@@ -58,7 +59,7 @@ class IterateSessions(UDSScanner):
         ):
             if not use_hooks:
                 self.logger.log_warning(
-                    f"Session {session:02x} is potentially available but could not be entered. "
+                    f"Session {g_repr(session)} is potentially available but could not be entered. "
                     f"Use --with-hooks to try to enter the session using hooks to scan for "
                     f"transitions available from that session."
                 )
@@ -70,7 +71,7 @@ class IterateSessions(UDSScanner):
 
             if isinstance(resp, NegativeResponse):
                 self.logger.log_notice(
-                    f"Received conditionsNotCorrect for session {session:02x}. "
+                    f"Received conditionsNotCorrect for session {g_repr(session)}. "
                     f"Successfully changed to the session with hooks."
                 )
                 resp = resp_
@@ -84,13 +85,13 @@ class IterateSessions(UDSScanner):
 
                 if isinstance(resp, NegativeResponse):
                     self.logger.log_error(
-                        f"Could not change to session 0x{session:02x} as part of stack: {resp}. "
+                        f"Could not change to session {g_repr(session)} as part of stack: {resp}. "
                         f"Try with --reset to reset between each iteration."
                     )
                     return False
             except Exception as e:
                 self.logger.log_error(
-                    f"Could not change to session 0x{session:02x} as part of stack: {e.__class__.__name__}. "
+                    f"Could not change to session {g_repr(session)} as part of stack: {g_repr(e)}. "
                     f"Try with --reset to reset between each iteration."
                 )
                 return False
@@ -114,12 +115,14 @@ class IterateSessions(UDSScanner):
 
             for stack in found[depth - 1]:
                 if stack:
-                    self.logger.log_summary(f"Starting from session: 0x{stack[-1]:02x}")
+                    self.logger.log_summary(
+                        f"Starting from session: {g_repr(stack[-1])}"
+                    )
 
                 for session in sessions:
                     if session in args.skip:
                         self.logger.log_info(
-                            f"Skipping session 0x{session:02x} as requested"
+                            f"Skipping session {g_repr(session)} as requested"
                         )
                         continue
 
@@ -157,7 +160,7 @@ class IterateSessions(UDSScanner):
                             sys.exit(1)
                     except Exception as e:
                         self.logger.log_error(
-                            f"Could not change to default session: {e.__class__.__name__}"
+                            f"Could not change to default session: {g_repr(e)}"
                         )
                         sys.exit(1)
 
@@ -181,12 +184,12 @@ class IterateSessions(UDSScanner):
                             == UDSErrorCodes.subFunctionNotSupported
                         ):
                             self.logger.log_info(
-                                f"Could not change to session 0x{session:02x}: {resp}"
+                                f"Could not change to session {g_repr(session)}: {resp}"
                             )
                             continue
 
                         self.logger.log_summary(
-                            f"Found session: 0x{session:02x} via stack: {stack}; {resp}"
+                            f"Found session: {g_repr(session)} via stack: {g_repr(stack)}; {resp}"
                         )
 
                         if not isinstance(resp, NegativeResponse):
@@ -209,7 +212,7 @@ class IterateSessions(UDSScanner):
 
                     except asyncio.TimeoutError:
                         self.logger.log_warning(
-                            f"Could not change to session 0x{session:02x}: Timeout"
+                            f"Could not change to session {g_repr(session)}: Timeout"
                         )
                         continue
 
@@ -221,10 +224,10 @@ class IterateSessions(UDSScanner):
 
             if session != previous_session:
                 previous_session = session
-                self.logger.log_summary(f"* Session {session:02x} ")
+                self.logger.log_summary(f"* Session {g_repr(session)} ")
 
             self.logger.log_summary(
-                f"\tvia stack: {'->'.join([f'{i:02x}' for i in res['stack']])}"
+                f"\tvia stack: {'->'.join([f'{g_repr(i)}' for i in res['stack']])}"
             )
 
         self.logger.log_summary(
@@ -241,9 +244,9 @@ class IterateSessions(UDSScanner):
             ):
                 if session != previous_session:
                     previous_session = session
-                    self.logger.log_summary(f"* Session {session:02x} ")
+                    self.logger.log_summary(f"* Session {g_repr(session)} ")
 
                 self.logger.log_summary(
-                    f"\tvia stack: {'->'.join([f'{i:02x}' for i in res['stack']])} "
+                    f"\tvia stack: {'->'.join([f'{g_repr(i)}' for i in res['stack']])} "
                     f"(NRC: {res['error']})"
                 )

--- a/src/gallia/udscan/scanner/simple_dtc.py
+++ b/src/gallia/udscan/scanner/simple_dtc.py
@@ -8,6 +8,7 @@ from gallia.uds.core.constants import CDTCSSubFuncs, DSCSubFuncs, UDSErrorCodes
 from gallia.uds.core.service import NegativeResponse
 from gallia.udscan.core import UDSScanner
 from gallia.udscan.utils import auto_int
+from gallia.utils import g_repr
 
 
 class DTCScanner(UDSScanner):
@@ -97,7 +98,7 @@ class DTCScanner(UDSScanner):
 
                         if sub_mask > 0:
                             self.logger.log_info(
-                                f"Trying to fetch with mask {sub_mask}"
+                                f"Trying to fetch with mask {g_repr(sub_mask)}"
                             )
                             dtcs.update(await self.fetch_error_codes(sub_mask, False))
             else:
@@ -187,9 +188,12 @@ class DTCScanner(UDSScanner):
     async def clear(self, args: Namespace) -> None:
         group_of_dtc: int = args.group_of_dtc
 
-        if not 0 <= group_of_dtc <= 0xFFFFFF:
+        min_group_of_dtc = 0
+        max_group_of_dtc = 0xFFFFFF
+
+        if not min_group_of_dtc <= group_of_dtc <= max_group_of_dtc:
             self.logger.log_error(
-                "The parameter group_of_dtc must be in the range 0x000000-0xffffff"
+                f"The parameter group_of_dtc must be in the range {g_repr(min_group_of_dtc)}-{g_repr(max_group_of_dtc)}"
             )
 
         resp = await self.ecu.clear_diagnostic_information(group_of_dtc)

--- a/src/gallia/udscan/scanner/simple_ecu_reset.py
+++ b/src/gallia/udscan/scanner/simple_ecu_reset.py
@@ -4,6 +4,7 @@ from argparse import Namespace
 from gallia.uds.core.service import NegativeResponse, UDSResponse
 from gallia.udscan.core import UDSScanner
 from gallia.udscan.utils import auto_int
+from gallia.utils import g_repr
 
 
 class EcuReset(UDSScanner):
@@ -22,21 +23,23 @@ class EcuReset(UDSScanner):
     async def main(self, args: Namespace) -> None:
         resp: UDSResponse = await self.ecu.set_session(args.session)
         if isinstance(resp, NegativeResponse):
-            self.logger.log_error(f"could not change to session: 0x{args.session:02x}")
+            self.logger.log_error(
+                f"could not change to session: {g_repr(args.session)}"
+            )
             return
 
         try:
-            self.logger.log_info(f"try sub-func: 0x{args.subfunc:02x}")
+            self.logger.log_info(f"try sub-func: {g_repr(args.subfunc)}")
             resp = await self.ecu.ecu_reset(args.subfunc)
             if isinstance(resp, NegativeResponse):
-                msg = f"ECU Reset 0x{args.subfunc:02x} failed in session: 0x{args.session:02x}: {resp}"
+                msg = f"ECU Reset {g_repr(args.subfunc)} failed in session: {g_repr(args.session)}: {resp}"
                 self.logger.log_error(msg)
             else:
-                self.logger.log_summary(f"ECU Reset 0x{args.subfunc:02x} succeeded")
+                self.logger.log_summary(f"ECU Reset {g_repr(args.subfunc)} succeeded")
         except asyncio.TimeoutError:
             self.logger.log_error("Timeout")
             await asyncio.sleep(10)
         except ConnectionError:
-            msg = f"Lost connection to ECU, session: 0x{args.session:02x} subFunc: 0x{args.subfunc:02x}"
+            msg = f"Lost connection to ECU, session: {g_repr(args.session)} subFunc: {g_repr(args.subfunc)}"
             self.logger.log_error(msg)
             return

--- a/src/gallia/udscan/scanner/simple_iocbi.py
+++ b/src/gallia/udscan/scanner/simple_iocbi.py
@@ -5,6 +5,7 @@ from argparse import Namespace
 from gallia.uds.core.service import NegativeResponse
 from gallia.udscan.core import UDSScanner
 from gallia.udscan.utils import auto_int, check_and_set_session
+from gallia.utils import g_repr
 
 
 class IOCBI(UDSScanner):
@@ -58,7 +59,7 @@ class IOCBI(UDSScanner):
             await check_and_set_session(self.ecu, args.session)
         except Exception as e:
             self.logger.log_critical(
-                f"Could not change to session: 0x{args.session:02x}: {e.__class__.__name__} {e}"
+                f"Could not change to session: {g_repr(args.session)}: {g_repr(e)}"
             )
             sys.exit(1)
 

--- a/src/gallia/udscan/scanner/simple_ping.py
+++ b/src/gallia/udscan/scanner/simple_ping.py
@@ -38,7 +38,7 @@ class Ping(UDSScanner):
                 break
             ret = await self.ecu.ping()
             if isinstance(ret, NegativeResponse):
-                self.logger.log_warning(f"{ret}")
+                self.logger.log_warning(ret)
             self.logger.log_summary("ECU is alive!")
             await asyncio.sleep(args.interval)
             i += 1

--- a/src/gallia/udscan/scanner/simple_read_by_identifier.py
+++ b/src/gallia/udscan/scanner/simple_read_by_identifier.py
@@ -4,6 +4,7 @@ from argparse import Namespace
 from gallia.uds.core.service import NegativeResponse
 from gallia.udscan.core import UDSScanner
 from gallia.udscan.utils import auto_int
+from gallia.utils import g_repr
 
 
 class ReadByIdentifier(UDSScanner):
@@ -24,7 +25,7 @@ class ReadByIdentifier(UDSScanner):
             if args.session != 0x01:
                 await self.ecu.set_session(args.session)
         except Exception as e:
-            self.logger.log_critical(f"fatal error: {e}")
+            self.logger.log_critical(f"fatal error: {g_repr(e)}")
             sys.exit(1)
 
         resp = await self.ecu.read_data_by_identifier(args.data_id)

--- a/src/gallia/udscan/scanner/simple_read_error_log.py
+++ b/src/gallia/udscan/scanner/simple_read_error_log.py
@@ -4,6 +4,7 @@ from argparse import Namespace
 from gallia.uds.core.service import NegativeResponse
 from gallia.udscan.core import UDSScanner
 from gallia.udscan.utils import auto_int
+from gallia.utils import g_repr
 
 
 class ReadErrorLog(UDSScanner):
@@ -29,7 +30,7 @@ class ReadErrorLog(UDSScanner):
         if sessions is None or len(sessions) == 0:
             sessions = list(range(1, 0x80))
             sessions = await self.ecu.find_sessions(sessions)
-            msg = f'Found {len(sessions)} sessions: {" ".join([hex(i) for i in sessions])}'
+            msg = f"Found {len(sessions)} sessions: {g_repr(sessions)}"
             self.logger.log_summary(msg)
 
         for sess in sessions:

--- a/src/gallia/udscan/scanner/simple_rmba.py
+++ b/src/gallia/udscan/scanner/simple_rmba.py
@@ -4,6 +4,7 @@ from argparse import Namespace
 from gallia.uds.core.service import NegativeResponse
 from gallia.udscan.core import UDSScanner
 from gallia.udscan.utils import auto_int, check_and_set_session
+from gallia.utils import g_repr
 
 
 class ReadMemoryByAddressScanner(UDSScanner):
@@ -32,7 +33,7 @@ class ReadMemoryByAddressScanner(UDSScanner):
             await check_and_set_session(self.ecu, args.session)
         except Exception as e:
             self.logger.log_critical(
-                f"Could not change to session: 0x{args.session:02x}: {e.__class__.__name__} {e}"
+                f"Could not change to session: {g_repr(args.session)}: {g_repr(e)}"
             )
             sys.exit(1)
 

--- a/src/gallia/udscan/scanner/simple_rtcl.py
+++ b/src/gallia/udscan/scanner/simple_rtcl.py
@@ -7,6 +7,7 @@ from typing import Union
 from gallia.uds.core.service import NegativeResponse, RoutineControlResponse
 from gallia.udscan.core import UDSScanner
 from gallia.udscan.utils import auto_int, check_and_set_session
+from gallia.utils import g_repr
 
 
 class RTCL(UDSScanner):
@@ -81,7 +82,7 @@ class RTCL(UDSScanner):
             await check_and_set_session(self.ecu, args.session)
         except Exception as e:
             self.logger.log_critical(
-                f"Could not change to session: 0x{args.session:02x}: {e.__class__.__name__} {e}"
+                f"Could not change to session: {g_repr(args.session)}: {g_repr(e)}"
             )
             sys.exit(1)
 

--- a/src/gallia/udscan/scanner/simple_send_pdu.py
+++ b/src/gallia/udscan/scanner/simple_send_pdu.py
@@ -14,6 +14,7 @@ from gallia.uds.core.service import (
 from gallia.uds.helpers import raise_for_error
 from gallia.udscan.core import UDSScanner
 from gallia.udscan.utils import auto_int
+from gallia.utils import g_repr
 
 
 class SendPDU(UDSScanner):
@@ -59,7 +60,7 @@ class SendPDU(UDSScanner):
                 pdu, config=UDSRequestConfig(max_retry=args.max_retry)
             )
         except UDSException as e:
-            self.logger.log_error(repr(e))
+            self.logger.log_error(g_repr(e))
             sys.exit(1)
 
         if isinstance(response, NegativeResponse):

--- a/src/gallia/udscan/scanner/simple_wmba.py
+++ b/src/gallia/udscan/scanner/simple_wmba.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from gallia.uds.core.service import NegativeResponse
 from gallia.udscan.core import UDSScanner
 from gallia.udscan.utils import auto_int, check_and_set_session
+from gallia.utils import g_repr
 
 
 class WriteMemoryByAddressScanner(UDSScanner):
@@ -38,7 +39,7 @@ class WriteMemoryByAddressScanner(UDSScanner):
             await check_and_set_session(self.ecu, args.session)
         except Exception as e:
             self.logger.log_critical(
-                f"Could not change to session: 0x{args.session:02x}: {e.__class__.__name__} {e}"
+                f"Could not change to session: {g_repr(args.session)}: {g_repr(e)}"
             )
             sys.exit(1)
 

--- a/src/gallia/udscan/scanner/simple_write_by_identifier.py
+++ b/src/gallia/udscan/scanner/simple_write_by_identifier.py
@@ -5,6 +5,7 @@ from argparse import Namespace
 from gallia.uds.core.service import NegativeResponse, UDSResponse
 from gallia.udscan.core import UDSScanner
 from gallia.udscan.utils import auto_int
+from gallia.utils import g_repr
 
 
 class WriteByIdentifier(UDSScanner):
@@ -40,11 +41,11 @@ class WriteByIdentifier(UDSScanner):
                     self.logger.log_critical(f"could not change to session: {resp}")
                     sys.exit(1)
         except Exception as e:
-            self.logger.log_critical(f"fatal error: {e}")
+            self.logger.log_critical(f"fatal error: {g_repr(e)}")
             sys.exit(1)
 
         resp = await self.ecu.write_data_by_identifier(args.data_id, args.data)
         if isinstance(resp, NegativeResponse):
-            self.logger.log_error(f"{resp}")
+            self.logger.log_error(resp)
         else:
             self.logger.log_info("Positive response")

--- a/src/gallia/utils.py
+++ b/src/gallia/utils.py
@@ -1,7 +1,11 @@
 import ipaddress
 import re
-from typing import Optional
+from enum import Enum
+from typing import Optional, Any
 from urllib.parse import urlparse
+
+from gallia.uds.core.utils import bytes_repr, int_repr
+from gallia.uds.core.service import NegativeResponse
 
 
 def split_host_port(
@@ -40,3 +44,41 @@ def camel_to_snake(s: str) -> str:
 def camel_to_dash(s: str) -> str:
     """Convert a CamelCase string to a dash-case string."""
     return camel_to_snake(s).replace("_", "-")
+
+
+def isotp_addr_repr(a: int) -> str:
+    """
+    Default string representation of a CAN id.
+    """
+    return f"{a:02x}"
+
+
+def can_id_repr(i: int) -> str:
+    """
+    Default string representation of a CAN id.
+    """
+    return f"{i:03x}"
+
+
+def g_repr(x: Any) -> str:
+    """
+    Object string representation with default gallia output settings.
+    """
+    if isinstance(x, Enum):
+        return x.name
+    if isinstance(x, bool):
+        return repr(x)
+    if isinstance(x, int):
+        return int_repr(x)
+    elif isinstance(x, str):
+        return x
+    elif isinstance(x, (bytes, bytearray)):
+        return bytes_repr(x)
+    elif isinstance(x, list):
+        return f'[{", ".join(g_repr(y) for y in x)}]'
+    elif isinstance(x, dict):
+        return f'{{{", ".join(f"{g_repr(k)}: {g_repr(v)}" for k, v in x.items())}}}'
+    elif isinstance(x, NegativeResponse):
+        return str(x)
+    else:
+        return repr(x)


### PR DESCRIPTION
Currently the output on the cli / in the logs is a mess.
E.g. for scan-sessions, sessions are sometimes printed in hex, sometimes in decimal format, sometimes in hex but as if they were decimal, which leads to max confusion:

![image](https://user-images.githubusercontent.com/104513847/170672286-308d15ea-8c3b-44bd-a86c-91a8280da4e7.png)

This PR aims to unify the output and does so, by offering a simple method `g_repr()`, which can be called for any object to be formatted in universal style. Should not be called for cases where a specific formatting (e.g. always decimal) is intended.
This method also handles lists and dicts, so there is no need to either fall back to default python formatting or to write extra code for such cases anymore.
With these changes applied, the same scan run looks as follows:

![image](https://user-images.githubusercontent.com/104513847/170673138-df8bfba2-de0a-4496-9b20-65327d8b6f71.png)
