### PR TITLE
fix(output): revert output for discover-can-ids

### DIFF
--- a/src/gallia/udscan/scanner/find_can_ids.py
+++ b/src/gallia/udscan/scanner/find_can_ids.py
@@ -148,7 +148,7 @@ class FindCanIDsScanner(DiscoveryScanner):
                 if isinstance(resp, NegativeResponse):
                     self.logger.log_summary(f"could not read did: {resp}")
                 else:
-                    self.logger.log_summary(f"response was: {resp}")
+                    self.logger.log_summary(f"response was: {resp.data_record!r}")
             except Exception as e:
                 self.logger.log_summary(f"reading description failed: {g_repr(e)}")
                 await asyncio.sleep(0.1)


### PR DESCRIPTION
In this case, the change in #136  was unintenional and is reverted to be able to read the ECU name in the output.