### PR TITLE
feat(scan-sessions): add fast search option

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,6 +73,7 @@ jobs:
     - name: Test scan-sessions
       run: |
         poetry run gallia scan-sessions --target "tcp-lines://127.0.0.1:20162" --no-dumpcap --depth 2
+        poetry run gallia scan-sessions --target "tcp-lines://127.0.0.1:20162" --no-dumpcap --fast
 
     - name: Test scan-identifiers
       run: |


### PR DESCRIPTION
Adds the option `--fast` which still finds any (session A, session B) transition that the current version finds, but leaves out many of the other (mostly useless) stacks.