### PR TITLE
feat(db): store sessions in the database

### DIFF
--- a/src/gallia/command/uds.py
+++ b/src/gallia/command/uds.py
@@ -115,10 +115,7 @@ class UDSScanner(Scanner):
             self._apply_implicit_logging_setting()
 
     def _apply_implicit_logging_setting(self) -> None:
-        if self._implicit_logging:
-            self.ecu.db_handler = self.db_handler
-        else:
-            self.ecu.db_handler = None
+        self.ecu.implicit_logging = self._implicit_logging
 
     async def setup(self, args: Namespace) -> None:
         await super().setup(args)
@@ -131,6 +128,8 @@ class UDSScanner(Scanner):
             max_retry=args.max_retries,
             power_supply=self.power_supply,
         )
+
+        self.ecu.db_handler = self.db_handler
 
         if self.db_handler is not None:
             try:

--- a/src/gallia/services/uds/ecu.py
+++ b/src/gallia/services/uds/ecu.py
@@ -69,6 +69,7 @@ class ECU(UDSClient):
         self.power_supply = power_supply
         self.state = ECUState()
         self.db_handler: DBHandler | None = None
+        self.implicit_logging = True
 
     async def connect(self) -> None:
         ...
@@ -264,6 +265,7 @@ class ECU(UDSClient):
         self,
         level: int,
         config: UDSRequestConfig | None = None,
+        use_db: bool = True,
     ) -> service.NegativeResponse | service.DiagnosticSessionControlResponse:
         config = config if config is not None else UDSRequestConfig()
 
@@ -271,6 +273,26 @@ class ECU(UDSClient):
             await self.set_session_pre(level, config=config)
 
         resp = await self.diagnostic_session_control(level, config=config)
+
+        if (
+            isinstance(resp, service.NegativeResponse)
+            and self.db_handler is not None
+            and use_db
+        ):
+            self.logger.debug(
+                "Could not switch to session. Trying with database transitions ..."
+            )
+
+            if self.db_handler is not None:
+                steps = await self.db_handler.get_session_transition(level)
+
+                self.logger.debug(f"Found the following steps in database: {steps}")
+
+                if steps is not None:
+                    for step in steps:
+                        await self.set_session(step, use_db=False)
+
+                    resp = await self.diagnostic_session_control(level, config=config)
 
         if not isinstance(resp, service.NegativeResponse) and not config.skip_hooks:
             await self.set_session_post(level, config=config)
@@ -483,7 +505,7 @@ class ECU(UDSClient):
             raise
         finally:
             try:
-                if self.db_handler is not None:
+                if self.implicit_logging and self.db_handler is not None:
                     mode = LogMode.implicit
 
                     if (


### PR DESCRIPTION
Adresses #17 

The idea behind this pull request is to remove the currently in place session scans at the start of most of the scanners and to replace them with the results from a full session scan as delivered by the scan-sessions script.
Therefore, the corresponding information is stored in a separate database table.

There is however still work to do here.
Currently only the logging to the database and the usage of this information during a session change is implemented and it is not clear if the current format, which can only stores transitions but no other information, is sufficient. Or in other words, can a broader format add enough value to justify replacing the simple session transition format?