### PR TITLE
chore: Remove pyxcp and vendor the types.py file

### DIFF
--- a/LICENSES/LGPL-3.0-only.txt
+++ b/LICENSES/LGPL-3.0-only.txt
@@ -1,0 +1,304 @@
+GNU LESSER GENERAL PUBLIC LICENSE
+Version 3, 29 June 2007
+
+Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+
+Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
+
+This version of the GNU Lesser General Public License incorporates the terms and conditions of version 3 of the GNU General Public License, supplemented by the additional permissions listed below.
+
+0. Additional Definitions.
+
+As used herein, "this License" refers to version 3 of the GNU Lesser General Public License, and the "GNU GPL" refers to version 3 of the GNU General Public License.
+
+"The Library" refers to a covered work governed by this License, other than an Application or a Combined Work as defined below.
+
+An "Application" is any work that makes use of an interface provided by the Library, but which is not otherwise based on the Library. Defining a subclass of a class defined by the Library is deemed a mode of using an interface provided by the Library.
+
+A "Combined Work" is a work produced by combining or linking an Application with the Library.  The particular version of the Library with which the Combined Work was made is also called the "Linked Version".
+
+The "Minimal Corresponding Source" for a Combined Work means the Corresponding Source for the Combined Work, excluding any source code for portions of the Combined Work that, considered in isolation, are based on the Application, and not on the Linked Version.
+
+The "Corresponding Application Code" for a Combined Work means the object code and/or source code for the Application, including any data and utility programs needed for reproducing the Combined Work from the Application, but excluding the System Libraries of the Combined Work.
+
+1. Exception to Section 3 of the GNU GPL.
+You may convey a covered work under sections 3 and 4 of this License without being bound by section 3 of the GNU GPL.
+
+2. Conveying Modified Versions.
+If you modify a copy of the Library, and, in your modifications, a facility refers to a function or data to be supplied by an Application that uses the facility (other than as an argument passed when the facility is invoked), then you may convey a copy of the modified version:
+
+     a) under this License, provided that you make a good faith effort to ensure that, in the event an Application does not supply the function or data, the facility still operates, and performs whatever part of its purpose remains meaningful, or
+
+     b) under the GNU GPL, with none of the additional permissions of this License applicable to that copy.
+
+3. Object Code Incorporating Material from Library Header Files.
+The object code form of an Application may incorporate material from a header file that is part of the Library.  You may convey such object code under terms of your choice, provided that, if the incorporated material is not limited to numerical parameters, data structure layouts and accessors, or small macros, inline functions and templates (ten or fewer lines in length), you do both of the following:
+
+     a) Give prominent notice with each copy of the object code that the Library is used in it and that the Library and its use are covered by this License.
+
+     b) Accompany the object code with a copy of the GNU GPL and this license document.
+
+4. Combined Works.
+You may convey a Combined Work under terms of your choice that, taken together, effectively do not restrict modification of the portions of the Library contained in the Combined Work and reverse engineering for debugging such modifications, if you also do each of the following:
+
+     a) Give prominent notice with each copy of the Combined Work that the Library is used in it and that the Library and its use are covered by this License.
+
+     b) Accompany the Combined Work with a copy of the GNU GPL and this license document.
+
+     c) For a Combined Work that displays copyright notices during execution, include the copyright notice for the Library among these notices, as well as a reference directing the user to the copies of the GNU GPL and this license document.
+
+     d) Do one of the following:
+
+           0) Convey the Minimal Corresponding Source under the terms of this License, and the Corresponding Application Code in a form suitable for, and under terms that permit, the user to recombine or relink the Application with a modified version of the Linked Version to produce a modified Combined Work, in the manner specified by section 6 of the GNU GPL for conveying Corresponding Source.
+
+          1) Use a suitable shared library mechanism for linking with the Library.  A suitable mechanism is one that (a) uses at run time a copy of the Library already present on the user's computer system, and (b) will operate properly with a modified version of the Library that is interface-compatible with the Linked Version.
+
+     e) Provide Installation Information, but only if you would otherwise be required to provide such information under section 6 of the GNU GPL, and only to the extent that such information is necessary to install and execute a modified version of the Combined Work produced by recombining or relinking the Application with a modified version of the Linked Version. (If you use option 4d0, the Installation Information must accompany the Minimal Corresponding Source and Corresponding Application Code. If you use option 4d1, you must provide the Installation Information in the manner specified by section 6 of the GNU GPL for conveying Corresponding Source.)
+
+5. Combined Libraries.
+You may place library facilities that are a work based on the Library side by side in a single library together with other library facilities that are not Applications and are not covered by this License, and convey such a combined library under terms of your choice, if you do both of the following:
+
+     a) Accompany the combined library with a copy of the same work based on the Library, uncombined with any other library facilities, conveyed under the terms of this License.
+
+     b) Give prominent notice with the combined library that part of it is a work based on the Library, and explaining where to find the accompanying uncombined form of the same work.
+
+6. Revised Versions of the GNU Lesser General Public License.
+The Free Software Foundation may publish revised and/or new versions of the GNU Lesser General Public License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number. If the Library as you received it specifies that a certain numbered version of the GNU Lesser General Public License "or any later version" applies to it, you have the option of following the terms and conditions either of that published version or of any later version published by the Free Software Foundation. If the Library as you received it does not specify a version number of the GNU Lesser General Public License, you may choose any version of the GNU Lesser General Public License ever published by the Free Software Foundation.
+
+If the Library as you received it specifies that a proxy can decide whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is permanent authorization for you to choose that version for the Library.
+
+GNU GENERAL PUBLIC LICENSE
+Version 3, 29 June 2007
+
+Copyright © 2007 Free Software Foundation, Inc. <http://fsf.org/>
+
+Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
+
+Preamble
+
+The GNU General Public License is a free, copyleft license for software and other kinds of works.
+
+The licenses for most software and other practical works are designed to take away your freedom to share and change the works. By contrast, the GNU General Public License is intended to guarantee your freedom to share and change all versions of a program--to make sure it remains free software for all its users. We, the Free Software Foundation, use the GNU General Public License for most of our software; it applies also to any other work released this way by its authors. You can apply it to your programs, too.
+
+When we speak of free software, we are referring to freedom, not price. Our General Public Licenses are designed to make sure that you have the freedom to distribute copies of free software (and charge for them if you wish), that you receive source code or can get it if you want it, that you can change the software or use pieces of it in new free programs, and that you know you can do these things.
+
+To protect your rights, we need to prevent others from denying you these rights or asking you to surrender the rights. Therefore, you have certain responsibilities if you distribute copies of the software, or if you modify it: responsibilities to respect the freedom of others.
+
+For example, if you distribute copies of such a program, whether gratis or for a fee, you must pass on to the recipients the same freedoms that you received. You must make sure that they, too, receive or can get the source code. And you must show them these terms so they know their rights.
+
+Developers that use the GNU GPL protect your rights with two steps: (1) assert copyright on the software, and (2) offer you this License giving you legal permission to copy, distribute and/or modify it.
+
+For the developers' and authors' protection, the GPL clearly explains that there is no warranty for this free software. For both users' and authors' sake, the GPL requires that modified versions be marked as changed, so that their problems will not be attributed erroneously to authors of previous versions.
+
+Some devices are designed to deny users access to install or run modified versions of the software inside them, although the manufacturer can do so. This is fundamentally incompatible with the aim of protecting users' freedom to change the software. The systematic pattern of such abuse occurs in the area of products for individuals to use, which is precisely where it is most unacceptable. Therefore, we have designed this version of the GPL to prohibit the practice for those products. If such problems arise substantially in other domains, we stand ready to extend this provision to those domains in future versions of the GPL, as needed to protect the freedom of users.
+
+Finally, every program is threatened constantly by software patents. States should not allow patents to restrict development and use of software on general-purpose computers, but in those that do, we wish to avoid the special danger that patents applied to a free program could make it effectively proprietary. To prevent this, the GPL assures that patents cannot be used to render the program non-free.
+
+The precise terms and conditions for copying, distribution and modification follow.
+
+TERMS AND CONDITIONS
+
+0. Definitions.
+
+“This License” refers to version 3 of the GNU General Public License.
+
+“Copyright” also means copyright-like laws that apply to other kinds of works, such as semiconductor masks.
+
+“The Program” refers to any copyrightable work licensed under this License. Each licensee is addressed as “you”. “Licensees” and “recipients” may be individuals or organizations.
+
+To “modify” a work means to copy from or adapt all or part of the work in a fashion requiring copyright permission, other than the making of an exact copy. The resulting work is called a “modified version” of the earlier work or a work “based on” the earlier work.
+
+A “covered work” means either the unmodified Program or a work based on the Program.
+
+To “propagate” a work means to do anything with it that, without permission, would make you directly or secondarily liable for infringement under applicable copyright law, except executing it on a computer or modifying a private copy. Propagation includes copying, distribution (with or without modification), making available to the public, and in some countries other activities as well.
+
+To “convey” a work means any kind of propagation that enables other parties to make or receive copies. Mere interaction with a user through a computer network, with no transfer of a copy, is not conveying.
+
+An interactive user interface displays “Appropriate Legal Notices” to the extent that it includes a convenient and prominently visible feature that (1) displays an appropriate copyright notice, and (2) tells the user that there is no warranty for the work (except to the extent that warranties are provided), that licensees may convey the work under this License, and how to view a copy of this License. If the interface presents a list of user commands or options, such as a menu, a prominent item in the list meets this criterion.
+
+1. Source Code.
+The “source code” for a work means the preferred form of the work for making modifications to it. “Object code” means any non-source form of a work.
+
+A “Standard Interface” means an interface that either is an official standard defined by a recognized standards body, or, in the case of interfaces specified for a particular programming language, one that is widely used among developers working in that language.
+
+The “System Libraries” of an executable work include anything, other than the work as a whole, that (a) is included in the normal form of packaging a Major Component, but which is not part of that Major Component, and (b) serves only to enable use of the work with that Major Component, or to implement a Standard Interface for which an implementation is available to the public in source code form. A “Major Component”, in this context, means a major essential component (kernel, window system, and so on) of the specific operating system (if any) on which the executable work runs, or a compiler used to produce the work, or an object code interpreter used to run it.
+
+The “Corresponding Source” for a work in object code form means all the source code needed to generate, install, and (for an executable work) run the object code and to modify the work, including scripts to control those activities. However, it does not include the work's System Libraries, or general-purpose tools or generally available free programs which are used unmodified in performing those activities but which are not part of the work. For example, Corresponding Source includes interface definition files associated with source files for the work, and the source code for shared libraries and dynamically linked subprograms that the work is specifically designed to require, such as by intimate data communication or control flow between those subprograms and other parts of the work.
+
+The Corresponding Source need not include anything that users can regenerate automatically from other parts of the Corresponding Source.
+
+The Corresponding Source for a work in source code form is that same work.
+
+2. Basic Permissions.
+All rights granted under this License are granted for the term of copyright on the Program, and are irrevocable provided the stated conditions are met. This License explicitly affirms your unlimited permission to run the unmodified Program. The output from running a covered work is covered by this License only if the output, given its content, constitutes a covered work. This License acknowledges your rights of fair use or other equivalent, as provided by copyright law.
+
+You may make, run and propagate covered works that you do not convey, without conditions so long as your license otherwise remains in force. You may convey covered works to others for the sole purpose of having them make modifications exclusively for you, or provide you with facilities for running those works, provided that you comply with the terms of this License in conveying all material for which you do not control copyright. Those thus making or running the covered works for you must do so exclusively on your behalf, under your direction and control, on terms that prohibit them from making any copies of your copyrighted material outside their relationship with you.
+
+Conveying under any other circumstances is permitted solely under the conditions stated below. Sublicensing is not allowed; section 10 makes it unnecessary.
+
+3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+No covered work shall be deemed part of an effective technological measure under any applicable law fulfilling obligations under article 11 of the WIPO copyright treaty adopted on 20 December 1996, or similar laws prohibiting or restricting circumvention of such measures.
+
+When you convey a covered work, you waive any legal power to forbid circumvention of technological measures to the extent such circumvention is effected by exercising rights under this License with respect to the covered work, and you disclaim any intention to limit operation or modification of the work as a means of enforcing, against the work's users, your or third parties' legal rights to forbid circumvention of technological measures.
+
+4. Conveying Verbatim Copies.
+You may convey verbatim copies of the Program's source code as you receive it, in any medium, provided that you conspicuously and appropriately publish on each copy an appropriate copyright notice; keep intact all notices stating that this License and any non-permissive terms added in accord with section 7 apply to the code; keep intact all notices of the absence of any warranty; and give all recipients a copy of this License along with the Program.
+
+You may charge any price or no price for each copy that you convey, and you may offer support or warranty protection for a fee.
+
+5. Conveying Modified Source Versions.
+You may convey a work based on the Program, or the modifications to produce it from the Program, in the form of source code under the terms of section 4, provided that you also meet all of these conditions:
+
+     a) The work must carry prominent notices stating that you modified it, and giving a relevant date.
+
+     b) The work must carry prominent notices stating that it is released under this License and any conditions added under section 7. This requirement modifies the requirement in section 4 to “keep intact all notices”.
+
+     c) You must license the entire work, as a whole, under this License to anyone who comes into possession of a copy. This License will therefore apply, along with any applicable section 7 additional terms, to the whole of the work, and all its parts, regardless of how they are packaged. This License gives no permission to license the work in any other way, but it does not invalidate such permission if you have separately received it.
+
+     d) If the work has interactive user interfaces, each must display Appropriate Legal Notices; however, if the Program has interactive interfaces that do not display Appropriate Legal Notices, your work need not make them do so.
+
+A compilation of a covered work with other separate and independent works, which are not by their nature extensions of the covered work, and which are not combined with it such as to form a larger program, in or on a volume of a storage or distribution medium, is called an “aggregate” if the compilation and its resulting copyright are not used to limit the access or legal rights of the compilation's users beyond what the individual works permit. Inclusion of a covered work in an aggregate does not cause this License to apply to the other parts of the aggregate.
+
+6. Conveying Non-Source Forms.
+You may convey a covered work in object code form under the terms of sections 4 and 5, provided that you also convey the machine-readable Corresponding Source under the terms of this License, in one of these ways:
+
+     a) Convey the object code in, or embodied in, a physical product (including a physical distribution medium), accompanied by the Corresponding Source fixed on a durable physical medium customarily used for software interchange.
+
+     b) Convey the object code in, or embodied in, a physical product (including a physical distribution medium), accompanied by a written offer, valid for at least three years and valid for as long as you offer spare parts or customer support for that product model, to give anyone who possesses the object code either (1) a copy of the Corresponding Source for all the software in the product that is covered by this License, on a durable physical medium customarily used for software interchange, for a price no more than your reasonable cost of physically performing this conveying of source, or (2) access to copy the Corresponding Source from a network server at no charge.
+
+     c) Convey individual copies of the object code with a copy of the written offer to provide the Corresponding Source. This alternative is allowed only occasionally and noncommercially, and only if you received the object code with such an offer, in accord with subsection 6b.
+
+     d) Convey the object code by offering access from a designated place (gratis or for a charge), and offer equivalent access to the Corresponding Source in the same way through the same place at no further charge. You need not require recipients to copy the Corresponding Source along with the object code. If the place to copy the object code is a network server, the Corresponding Source may be on a different server (operated by you or a third party) that supports equivalent copying facilities, provided you maintain clear directions next to the object code saying where to find the Corresponding Source. Regardless of what server hosts the Corresponding Source, you remain obligated to ensure that it is available for as long as needed to satisfy these requirements.
+
+     e) Convey the object code using peer-to-peer transmission, provided you inform other peers where the object code and Corresponding Source of the work are being offered to the general public at no charge under subsection 6d.
+
+A separable portion of the object code, whose source code is excluded from the Corresponding Source as a System Library, need not be included in conveying the object code work.
+
+A “User Product” is either (1) a “consumer product”, which means any tangible personal property which is normally used for personal, family, or household purposes, or (2) anything designed or sold for incorporation into a dwelling. In determining whether a product is a consumer product, doubtful cases shall be resolved in favor of coverage. For a particular product received by a particular user, “normally used” refers to a typical or common use of that class of product, regardless of the status of the particular user or of the way in which the particular user actually uses, or expects or is expected to use, the product. A product is a consumer product regardless of whether the product has substantial commercial, industrial or non-consumer uses, unless such uses represent the only significant mode of use of the product.
+
+“Installation Information” for a User Product means any methods, procedures, authorization keys, or other information required to install and execute modified versions of a covered work in that User Product from a modified version of its Corresponding Source. The information must suffice to ensure that the continued functioning of the modified object code is in no case prevented or interfered with solely because modification has been made.
+
+If you convey an object code work under this section in, or with, or specifically for use in, a User Product, and the conveying occurs as part of a transaction in which the right of possession and use of the User Product is transferred to the recipient in perpetuity or for a fixed term (regardless of how the transaction is characterized), the Corresponding Source conveyed under this section must be accompanied by the Installation Information. But this requirement does not apply if neither you nor any third party retains the ability to install modified object code on the User Product (for example, the work has been installed in ROM).
+
+The requirement to provide Installation Information does not include a requirement to continue to provide support service, warranty, or updates for a work that has been modified or installed by the recipient, or for the User Product in which it has been modified or installed. Access to a network may be denied when the modification itself materially and adversely affects the operation of the network or violates the rules and protocols for communication across the network.
+
+Corresponding Source conveyed, and Installation Information provided, in accord with this section must be in a format that is publicly documented (and with an implementation available to the public in source code form), and must require no special password or key for unpacking, reading or copying.
+
+7. Additional Terms.
+“Additional permissions” are terms that supplement the terms of this License by making exceptions from one or more of its conditions. Additional permissions that are applicable to the entire Program shall be treated as though they were included in this License, to the extent that they are valid under applicable law. If additional permissions apply only to part of the Program, that part may be used separately under those permissions, but the entire Program remains governed by this License without regard to the additional permissions.
+
+When you convey a copy of a covered work, you may at your option remove any additional permissions from that copy, or from any part of it. (Additional permissions may be written to require their own removal in certain cases when you modify the work.) You may place additional permissions on material, added by you to a covered work, for which you have or can give appropriate copyright permission.
+
+Notwithstanding any other provision of this License, for material you add to a covered work, you may (if authorized by the copyright holders of that material) supplement the terms of this License with terms:
+
+     a) Disclaiming warranty or limiting liability differently from the terms of sections 15 and 16 of this License; or
+
+     b) Requiring preservation of specified reasonable legal notices or author attributions in that material or in the Appropriate Legal Notices displayed by works containing it; or
+
+     c) Prohibiting misrepresentation of the origin of that material, or requiring that modified versions of such material be marked in reasonable ways as different from the original version; or
+
+     d) Limiting the use for publicity purposes of names of licensors or authors of the material; or
+
+     e) Declining to grant rights under trademark law for use of some trade names, trademarks, or service marks; or
+
+     f) Requiring indemnification of licensors and authors of that material by anyone who conveys the material (or modified versions of it) with contractual assumptions of liability to the recipient, for any liability that these contractual assumptions directly impose on those licensors and authors.
+
+All other non-permissive additional terms are considered “further restrictions” within the meaning of section 10. If the Program as you received it, or any part of it, contains a notice stating that it is governed by this License along with a term that is a further restriction, you may remove that term. If a license document contains a further restriction but permits relicensing or conveying under this License, you may add to a covered work material governed by the terms of that license document, provided that the further restriction does not survive such relicensing or conveying.
+
+If you add terms to a covered work in accord with this section, you must place, in the relevant source files, a statement of the additional terms that apply to those files, or a notice indicating where to find the applicable terms.
+
+Additional terms, permissive or non-permissive, may be stated in the form of a separately written license, or stated as exceptions; the above requirements apply either way.
+
+8. Termination.
+You may not propagate or modify a covered work except as expressly provided under this License. Any attempt otherwise to propagate or modify it is void, and will automatically terminate your rights under this License (including any patent licenses granted under the third paragraph of section 11).
+
+However, if you cease all violation of this License, then your license from a particular copyright holder is reinstated (a) provisionally, unless and until the copyright holder explicitly and finally terminates your license, and (b) permanently, if the copyright holder fails to notify you of the violation by some reasonable means prior to 60 days after the cessation.
+
+Moreover, your license from a particular copyright holder is reinstated permanently if the copyright holder notifies you of the violation by some reasonable means, this is the first time you have received notice of violation of this License (for any work) from that copyright holder, and you cure the violation prior to 30 days after your receipt of the notice.
+
+Termination of your rights under this section does not terminate the licenses of parties who have received copies or rights from you under this License. If your rights have been terminated and not permanently reinstated, you do not qualify to receive new licenses for the same material under section 10.
+
+9. Acceptance Not Required for Having Copies.
+You are not required to accept this License in order to receive or run a copy of the Program. Ancillary propagation of a covered work occurring solely as a consequence of using peer-to-peer transmission to receive a copy likewise does not require acceptance. However, nothing other than this License grants you permission to propagate or modify any covered work. These actions infringe copyright if you do not accept this License. Therefore, by modifying or propagating a covered work, you indicate your acceptance of this License to do so.
+
+10. Automatic Licensing of Downstream Recipients.
+Each time you convey a covered work, the recipient automatically receives a license from the original licensors, to run, modify and propagate that work, subject to this License. You are not responsible for enforcing compliance by third parties with this License.
+
+An “entity transaction” is a transaction transferring control of an organization, or substantially all assets of one, or subdividing an organization, or merging organizations. If propagation of a covered work results from an entity transaction, each party to that transaction who receives a copy of the work also receives whatever licenses to the work the party's predecessor in interest had or could give under the previous paragraph, plus a right to possession of the Corresponding Source of the work from the predecessor in interest, if the predecessor has it or can get it with reasonable efforts.
+
+You may not impose any further restrictions on the exercise of the rights granted or affirmed under this License. For example, you may not impose a license fee, royalty, or other charge for exercise of rights granted under this License, and you may not initiate litigation (including a cross-claim or counterclaim in a lawsuit) alleging that any patent claim is infringed by making, using, selling, offering for sale, or importing the Program or any portion of it.
+
+11. Patents.
+A “contributor” is a copyright holder who authorizes use under this License of the Program or a work on which the Program is based. The work thus licensed is called the contributor's “contributor version”.
+
+A contributor's “essential patent claims” are all patent claims owned or controlled by the contributor, whether already acquired or hereafter acquired, that would be infringed by some manner, permitted by this License, of making, using, or selling its contributor version, but do not include claims that would be infringed only as a consequence of further modification of the contributor version. For purposes of this definition, “control” includes the right to grant patent sublicenses in a manner consistent with the requirements of this License.
+
+Each contributor grants you a non-exclusive, worldwide, royalty-free patent license under the contributor's essential patent claims, to make, use, sell, offer for sale, import and otherwise run, modify and propagate the contents of its contributor version.
+
+In the following three paragraphs, a “patent license” is any express agreement or commitment, however denominated, not to enforce a patent (such as an express permission to practice a patent or covenant not to sue for patent infringement). To “grant” such a patent license to a party means to make such an agreement or commitment not to enforce a patent against the party.
+
+If you convey a covered work, knowingly relying on a patent license, and the Corresponding Source of the work is not available for anyone to copy, free of charge and under the terms of this License, through a publicly available network server or other readily accessible means, then you must either (1) cause the Corresponding Source to be so available, or (2) arrange to deprive yourself of the benefit of the patent license for this particular work, or (3) arrange, in a manner consistent with the requirements of this License, to extend the patent license to downstream recipients. “Knowingly relying” means you have actual knowledge that, but for the patent license, your conveying the covered work in a country, or your recipient's use of the covered work in a country, would infringe one or more identifiable patents in that country that you have reason to believe are valid.
+
+If, pursuant to or in connection with a single transaction or arrangement, you convey, or propagate by procuring conveyance of, a covered work, and grant a patent license to some of the parties receiving the covered work authorizing them to use, propagate, modify or convey a specific copy of the covered work, then the patent license you grant is automatically extended to all recipients of the covered work and works based on it.
+
+A patent license is “discriminatory” if it does not include within the scope of its coverage, prohibits the exercise of, or is conditioned on the non-exercise of one or more of the rights that are specifically granted under this License. You may not convey a covered work if you are a party to an arrangement with a third party that is in the business of distributing software, under which you make payment to the third party based on the extent of your activity of conveying the work, and under which the third party grants, to any of the parties who would receive the covered work from you, a discriminatory patent license (a) in connection with copies of the covered work conveyed by you (or copies made from those copies), or (b) primarily for and in connection with specific products or compilations that contain the covered work, unless you entered into that arrangement, or that patent license was granted, prior to 28 March 2007.
+
+Nothing in this License shall be construed as excluding or limiting any implied license or other defenses to infringement that may otherwise be available to you under applicable patent law.
+
+12. No Surrender of Others' Freedom.
+If conditions are imposed on you (whether by court order, agreement or otherwise) that contradict the conditions of this License, they do not excuse you from the conditions of this License. If you cannot convey a covered work so as to satisfy simultaneously your obligations under this License and any other pertinent obligations, then as a consequence you may not convey it at all. For example, if you agree to terms that obligate you to collect a royalty for further conveying from those to whom you convey the Program, the only way you could satisfy both those terms and this License would be to refrain entirely from conveying the Program.
+
+13. Use with the GNU Affero General Public License.
+Notwithstanding any other provision of this License, you have permission to link or combine any covered work with a work licensed under version 3 of the GNU Affero General Public License into a single combined work, and to convey the resulting work. The terms of this License will continue to apply to the part which is the covered work, but the special requirements of the GNU Affero General Public License, section 13, concerning interaction through a network will apply to the combination as such.
+
+14. Revised Versions of this License.
+The Free Software Foundation may publish revised and/or new versions of the GNU General Public License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number. If the Program specifies that a certain numbered version of the GNU General Public License “or any later version” applies to it, you have the option of following the terms and conditions either of that numbered version or of any later version published by the Free Software Foundation. If the Program does not specify a version number of the GNU General Public License, you may choose any version ever published by the Free Software Foundation.
+
+If the Program specifies that a proxy can decide which future versions of the GNU General Public License can be used, that proxy's public statement of acceptance of a version permanently authorizes you to choose that version for the Program.
+
+Later license versions may give you additional or different permissions. However, no additional obligations are imposed on any author or copyright holder as a result of your choosing to follow a later version.
+
+15. Disclaimer of Warranty.
+THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW. EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM “AS IS” WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU. SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+16. Limitation of Liability.
+IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+17. Interpretation of Sections 15 and 16.
+If the disclaimer of warranty and limitation of liability provided above cannot be given local legal effect according to their terms, reviewing courts shall apply local law that most closely approximates an absolute waiver of all civil liability in connection with the Program, unless a warranty or assumption of liability accompanies a copy of the Program in return for a fee.
+
+END OF TERMS AND CONDITIONS
+
+How to Apply These Terms to Your New Programs
+
+If you develop a new program, and you want it to be of the greatest possible use to the public, the best way to achieve this is to make it free software which everyone can redistribute and change under these terms.
+
+To do so, attach the following notices to the program. It is safest to attach them to the start of each source file to most effectively state the exclusion of warranty; and each file should have at least the “copyright” line and a pointer to where the full notice is found.
+
+     <one line to give the program's name and a brief idea of what it does.>
+     Copyright (C) <year>  <name of author>
+
+     This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+
+     This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+     You should have received a copy of the GNU General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program does terminal interaction, make it output a short notice like this when it starts in an interactive mode:
+
+     <program>  Copyright (C) <year>  <name of author>
+     This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+     This is free software, and you are welcome to redistribute it under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate parts of the General Public License. Of course, your program's commands might be different; for a GUI interface, you would use an “about box”.
+
+You should also get your employer (if you work as a programmer) or school, if any, to sign a “copyright disclaimer” for the program, if necessary. For more information on this, and how to apply and follow the GNU GPL, see <http://www.gnu.org/licenses/>.
+
+The GNU General Public License does not permit incorporating your program into proprietary programs. If your program is a subroutine library, you may consider it more useful to permit linking proprietary applications with the library. If this is what you want to do, use the GNU Lesser General Public License instead of this License. But first, please read <http://www.gnu.org/philosophy/why-not-lgpl.html>.

--- a/poetry.lock
+++ b/poetry.lock
@@ -388,22 +388,6 @@ python-versions = "*"
 test = ["coverage[toml] (==5.2)", "pytest (>=6.0.0)", "pytest-mypy-plugins (==1.9.3)"]
 
 [[package]]
-name = "mako"
-version = "1.2.0"
-description = "A super-fast templating language that borrows the best ideas from the existing templating languages."
-category = "main"
-optional = false
-python-versions = ">=3.7"
-
-[package.dependencies]
-MarkupSafe = ">=0.9.2"
-
-[package.extras]
-babel = ["babel"]
-lingua = ["lingua"]
-testing = ["pytest"]
-
-[[package]]
 name = "markdown-it-py"
 version = "2.1.0"
 description = "Python port of markdown-it. Markdown parsing, done right!"
@@ -428,7 +412,7 @@ testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions"]
 name = "markupsafe"
 version = "2.1.1"
 description = "Safely add untrusted strings to HTML/XML markup."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 
@@ -593,17 +577,6 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
-name = "pybind11"
-version = "2.9.2"
-description = "Seamless operability between C++11 and Python"
-category = "main"
-optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
-
-[package.extras]
-global = ["pybind11-global (==2.9.2)"]
-
-[[package]]
 name = "pycodestyle"
 version = "2.8.0"
 description = "Python style guide checker"
@@ -700,17 +673,6 @@ python-versions = ">=3.6.8"
 
 [package.extras]
 diagrams = ["railroad-diagrams", "jinja2"]
-
-[[package]]
-name = "pyserial"
-version = "3.5"
-description = "Python Serial Port Extension"
-category = "main"
-optional = false
-python-versions = "*"
-
-[package.extras]
-cp2110 = ["hidapi"]
 
 [[package]]
 name = "pytest"
@@ -850,41 +812,12 @@ optional = false
 python-versions = "*"
 
 [[package]]
-name = "pyusb"
-version = "1.2.1"
-description = "Python USB access module"
-category = "main"
-optional = false
-python-versions = ">=3.6.0"
-
-[[package]]
 name = "pywin32"
 version = "304"
 description = "Python for Window Extensions"
 category = "main"
 optional = false
 python-versions = "*"
-
-[[package]]
-name = "pyxcp"
-version = "0.18.51"
-description = "Universal Calibration Protocol for Python"
-category = "main"
-optional = false
-python-versions = ">=3.7"
-
-[package.dependencies]
-construct = ">=2.10.67,<3.0.0"
-Mako = ">=1.1.6,<2.0.0"
-pyserial = ">=3.5,<4.0"
-python-can = ">=4.0.0"
-pyusb = ">=1.2.1,<2.0.0"
-setuptools-cpp = ">=0.1.0,<1.0.0"
-toml = ">=0.10.2,<1.0.0"
-uptime = ">=3.0.1"
-
-[package.extras]
-doc = ["sphinx", "sphinxcontrib-napoleon"]
 
 [[package]]
 name = "pyyaml"
@@ -938,17 +871,6 @@ python-versions = ">=3"
 
 [package.extras]
 dev = ["build", "pytest", "pytest-timeout"]
-
-[[package]]
-name = "setuptools-cpp"
-version = "0.1.0"
-description = "Simplified packaging for pybind11-based C++ extensions"
-category = "main"
-optional = false
-python-versions = ">=3.6,<4.0"
-
-[package.dependencies]
-pybind11 = "*"
 
 [[package]]
 name = "snowballstemmer"
@@ -1091,7 +1013,7 @@ widechars = ["wcwidth"]
 name = "toml"
 version = "0.10.2"
 description = "Python Library for Tom's Obvious, Minimal Language"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
@@ -1142,14 +1064,6 @@ description = "Ultra fast JSON encoder and decoder for Python"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
-
-[[package]]
-name = "uptime"
-version = "3.0.1"
-description = "Cross-platform uptime library"
-category = "main"
-optional = false
-python-versions = "*"
 
 [[package]]
 name = "urllib3"
@@ -1221,7 +1135,7 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.9,<3.11"
-content-hash = "0cf7ca4acaeb73096642f036fc9d4563734a215a2729a205c977ca42f9f95b0b"
+content-hash = "47291223d92801cbbb903b0c657ce3b1078c401aa396b76eb2402982fd568218"
 
 [metadata.files]
 aiofiles = [
@@ -1594,10 +1508,6 @@ lxml-stubs = [
     {file = "lxml-stubs-0.4.0.tar.gz", hash = "sha256:184877b42127256abc2b932ba8bd0ab5ea80bd0b0fee618d16daa40e0b71abee"},
     {file = "lxml_stubs-0.4.0-py3-none-any.whl", hash = "sha256:3b381e9e82397c64ea3cc4d6f79d1255d015f7b114806d4826218805c10ec003"},
 ]
-mako = [
-    {file = "Mako-1.2.0-py3-none-any.whl", hash = "sha256:23aab11fdbbb0f1051b93793a58323ff937e98e34aece1c4219675122e57e4ba"},
-    {file = "Mako-1.2.0.tar.gz", hash = "sha256:9a7c7e922b87db3686210cf49d5d767033a41d4010b284e747682c92bddd8b39"},
-]
 markdown-it-py = [
     {file = "markdown-it-py-2.1.0.tar.gz", hash = "sha256:cf7e59fed14b5ae17c0006eff14a2d9a00ed5f3a846148153899a0224e2c07da"},
     {file = "markdown_it_py-2.1.0-py3-none-any.whl", hash = "sha256:93de681e5c021a432c63147656fe21790bc01231e0cd2da73626f1aa3ac0fe27"},
@@ -1828,10 +1738,6 @@ py = [
     {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
     {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
 ]
-pybind11 = [
-    {file = "pybind11-2.9.2-py2.py3-none-any.whl", hash = "sha256:20f56674da31c96bca7569b91e60f2bd30d693f0728541412ec927574f7bc9df"},
-    {file = "pybind11-2.9.2.tar.gz", hash = "sha256:e5541f8bccf9111d1a94f7897593b55c4cf1a28d5e8cfc8225a855651f011071"},
-]
 pycodestyle = [
     {file = "pycodestyle-2.8.0-py2.py3-none-any.whl", hash = "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20"},
     {file = "pycodestyle-2.8.0.tar.gz", hash = "sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f"},
@@ -1863,10 +1769,6 @@ pylsp-rope = [
 pyparsing = [
     {file = "pyparsing-3.0.9-py3-none-any.whl", hash = "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"},
     {file = "pyparsing-3.0.9.tar.gz", hash = "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb"},
-]
-pyserial = [
-    {file = "pyserial-3.5-py2.py3-none-any.whl", hash = "sha256:c4451db6ba391ca6ca299fb3ec7bae67a5c55dde170964c7a14ceefec02f2cf0"},
-    {file = "pyserial-3.5.tar.gz", hash = "sha256:3c77e014170dfffbd816e6ffc205e9842efb10be9f58ec16d3e8675b4925cddb"},
 ]
 pytest = [
     {file = "pytest-7.1.2-py3-none-any.whl", hash = "sha256:13d0e3ccfc2b6e26be000cb6568c832ba67ba32e719443bfe725814d3c42433c"},
@@ -1905,10 +1807,6 @@ pytz = [
     {file = "pytz-2022.1-py2.py3-none-any.whl", hash = "sha256:e68985985296d9a66a881eb3193b0906246245294a881e7c8afe623866ac6a5c"},
     {file = "pytz-2022.1.tar.gz", hash = "sha256:1e760e2fe6a8163bc0b3d9a19c4f84342afa0a2affebfaa84b01b978a02ecaa7"},
 ]
-pyusb = [
-    {file = "pyusb-1.2.1-py3-none-any.whl", hash = "sha256:2b4c7cb86dbadf044dfb9d3a4ff69fd217013dbe78a792177a3feb172449ea36"},
-    {file = "pyusb-1.2.1.tar.gz", hash = "sha256:a4cc7404a203144754164b8b40994e2849fde1cfff06b08492f12fff9d9de7b9"},
-]
 pywin32 = [
     {file = "pywin32-304-cp310-cp310-win32.whl", hash = "sha256:3c7bacf5e24298c86314f03fa20e16558a4e4138fc34615d7de4070c23e65af3"},
     {file = "pywin32-304-cp310-cp310-win_amd64.whl", hash = "sha256:4f32145913a2447736dad62495199a8e280a77a0ca662daa2332acf849f0be48"},
@@ -1924,21 +1822,6 @@ pywin32 = [
     {file = "pywin32-304-cp38-cp38-win_amd64.whl", hash = "sha256:ead865a2e179b30fb717831f73cf4373401fc62fbc3455a0889a7ddac848f83e"},
     {file = "pywin32-304-cp39-cp39-win32.whl", hash = "sha256:25746d841201fd9f96b648a248f731c1dec851c9a08b8e33da8b56148e4c65cc"},
     {file = "pywin32-304-cp39-cp39-win_amd64.whl", hash = "sha256:d24a3382f013b21aa24a5cfbfad5a2cd9926610c0affde3e8ab5b3d7dbcf4ac9"},
-]
-pyxcp = [
-    {file = "pyxcp-0.18.51-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0bb48d4160c6a27fa83ea36bed32259d1edce55061ccbe890e460eca29f7acbe"},
-    {file = "pyxcp-0.18.51-cp310-cp310-win32.whl", hash = "sha256:882d253edeb754fb9a8d0d9892612d40d962d8f2088f9fa44f9a61a8bcb08447"},
-    {file = "pyxcp-0.18.51-cp310-cp310-win_amd64.whl", hash = "sha256:197cc3e1dcbd14b390330130badd4c92f9aad1947bc9e4824325a79ba6137068"},
-    {file = "pyxcp-0.18.51-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:60d51c20d7130b80d9c53b98e6a1b475c1c7d432d4b13a8c96da85f9f844fc34"},
-    {file = "pyxcp-0.18.51-cp37-cp37m-win32.whl", hash = "sha256:247cae8037bc76e29972631fe335b45ad105f7a8725a43e0067a123627449c4e"},
-    {file = "pyxcp-0.18.51-cp37-cp37m-win_amd64.whl", hash = "sha256:5fc34e9e3a6f6f71675cf56d3abfbbcd6cede6140a3f89a02a983b15669e93e7"},
-    {file = "pyxcp-0.18.51-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:e1f6e2f2f73388c291f493dcfbd2c56e2837ade2660cb8c506c67c53dd2b9f2d"},
-    {file = "pyxcp-0.18.51-cp38-cp38-win32.whl", hash = "sha256:d7c888e8d20647f9164315b2870bee537a576030102666c7d7f5ee4eacfea1e2"},
-    {file = "pyxcp-0.18.51-cp38-cp38-win_amd64.whl", hash = "sha256:9ffadfa8a483cf7367e4ecf5c99f40a847343ab9327e55298855bc803ff194a5"},
-    {file = "pyxcp-0.18.51-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:2044e835dac28db85298ae9f03288d8045bcf3ffa826f30348cbed55e4400eaa"},
-    {file = "pyxcp-0.18.51-cp39-cp39-win32.whl", hash = "sha256:f4c285026813c456df81de41ead591f906f16e7379bb81fe3ec8659a1db45740"},
-    {file = "pyxcp-0.18.51-cp39-cp39-win_amd64.whl", hash = "sha256:7babf93e4636078edc6c7e6b1b55e787515caf1bad06c5e19fdbd668ef7cf399"},
-    {file = "pyxcp-0.18.51.tar.gz", hash = "sha256:9b66cb5b7aeff742bbf137cea7b4d35d4e7c1610a1bb97a8c96a54b2138fb7c2"},
 ]
 pyyaml = [
     {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},
@@ -1986,10 +1869,6 @@ reuse = [
 rope = [
     {file = "rope-1.1.1-py3-none-any.whl", hash = "sha256:216390b6342bde8ef1f27a6663554de0ea0b1fdad7c421deb3d5a3f6c5fc01e7"},
     {file = "rope-1.1.1.tar.gz", hash = "sha256:13048ff0245a0fa187f282697a55add46e4ccf083e7670f868bdf54ee9e47f2e"},
-]
-setuptools-cpp = [
-    {file = "setuptools_cpp-0.1.0-py3-none-any.whl", hash = "sha256:cd8179c038a12dbf2914999928f193f54d4713fd11715efdc5d6f450f663c8bd"},
-    {file = "setuptools_cpp-0.1.0.tar.gz", hash = "sha256:4fd5e08603237578d06d28efd592d9847b523ede3e502f660be44b1e6254674d"},
 ]
 snowballstemmer = [
     {file = "snowballstemmer-2.2.0-py2.py3-none-any.whl", hash = "sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a"},
@@ -2107,9 +1986,6 @@ ujson = [
     {file = "ujson-5.3.0-pp38-pypy38_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c5696c99a7dd567566c18490e8e346b2657967feb1e3c2004e91dbb253db0894"},
     {file = "ujson-5.3.0-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:a68d5a8a46712ffe86db8ae1b4311714db534725521c71fd4c9e1cd062dae9a4"},
     {file = "ujson-5.3.0.tar.gz", hash = "sha256:ab938777b3ac0372231ee654a7f6a13787e587b1ca268d8aa7e6fb6846e477d0"},
-]
-uptime = [
-    {file = "uptime-3.0.1.tar.gz", hash = "sha256:7c300254775b807ce46e3dcbcda30aa3b9a204b9c57a7ac1e79ee6dbe3942973"},
 ]
 urllib3 = [
     {file = "urllib3-1.26.9-py2.py3-none-any.whl", hash = "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,10 +28,10 @@ aiohttp = "^3.8.1"
 aiofiles = "^0.8.0"
 aiosqlite = "^0.17.0"
 argcomplete = "^2.0.0"
-pyxcp = "^0.18.0"
 zstandard = "^0.17.0"
 python-can = "^4.0.0"
 tabulate = "^0.8.9"
+construct = "^2.10.68"
 
 [tool.poetry.dev-dependencies]
 black = "^22.1.0"

--- a/src/gallia/services/xcp/__init__.py
+++ b/src/gallia/services/xcp/__init__.py
@@ -4,8 +4,7 @@
 
 from typing import Any, Optional
 
-import pyxcp
-import pyxcp.types
+from gallia.services.xcp import types
 
 from gallia.penlog import Logger
 from gallia.transports.base import BaseTransport
@@ -23,7 +22,7 @@ class XCPService:
     async def request(self, data: bytes, timeout: Optional[float] = None) -> bytes:
         t = timeout if timeout else self.timeout
         resp = await self.transport.request(data, t)
-        header = pyxcp.types.Response.parse(resp)
+        header = types.Response.parse(resp)
         self.logger.log_info(header)
         if int(header.type) != 255:
             raise ValueError(
@@ -35,9 +34,9 @@ class XCPService:
     async def connect(self) -> None:
         self.logger.log_info("XCP CONNECT")
         resp = await self.request(bytes([0xFF, 0x00]))
-        tmp = pyxcp.types.ConnectResponsePartial.parse(resp)
+        tmp = types.ConnectResponsePartial.parse(resp)
         self.byte_order = tmp.commModeBasic.byteOrder
-        tmp = pyxcp.types.ConnectResponse.parse(resp, byteOrder=self.byte_order)
+        tmp = types.ConnectResponse.parse(resp, byteOrder=self.byte_order)
         self.logger.log_info(tmp)
         self.logger.log_summary("XCP CONNECT -> OK")
 
@@ -50,14 +49,14 @@ class XCPService:
     async def get_status(self) -> None:
         self.logger.log_info("XCP GET_STATUS")
         resp = await self.request(bytes([0xFD]))
-        tmp = pyxcp.types.GetStatusResponse.parse(resp, byteOrder=self.byte_order)
+        tmp = types.GetStatusResponse.parse(resp, byteOrder=self.byte_order)
         self.logger.log_info(tmp)
         self.logger.log_summary("XCP GET_STATUS -> OK")
 
     async def get_comm_mode_info(self) -> None:
         self.logger.log_info("XCP GET_COMM_MODE_INFO")
         resp = await self.request(bytes([0xFB]))
-        tmp = pyxcp.types.GetCommModeInfoResponse.parse(
+        tmp = types.GetCommModeInfoResponse.parse(
             resp,
             byteOrder=self.byte_order,
         )
@@ -67,7 +66,7 @@ class XCPService:
     async def get_id(self, id_: int) -> None:
         self.logger.log_info(f"XCP GET_ID({id_})")
         resp = await self.request(bytes([0xFA, id_]))
-        tmp = pyxcp.types.GetIDResponse.parse(resp, byteOrder=self.byte_order)
+        tmp = types.GetIDResponse.parse(resp, byteOrder=self.byte_order)
         self.logger.log_info(tmp)
         self.logger.log_summary(f"XCP GET_ID({id_}) -> OK")
 

--- a/src/gallia/services/xcp/types.py
+++ b/src/gallia/services/xcp/types.py
@@ -1,0 +1,890 @@
+# SPDX-FileCopyrightText: Christoph Schueler <cpu12.gems@googlemail.com>
+#
+# SPDX-License-Identifier: LGPL-3.0-only
+#
+# https://github.com/christoph2/pyxcp/blob/9d37f4bb422e3d1948f76da159dbf112cca5adcd/pyxcp/types.py
+
+import enum
+from collections import namedtuple
+
+from construct import BitsInteger
+from construct import BitStruct
+from construct import Enum
+from construct import Flag
+from construct import GreedyBytes
+from construct import GreedyRange
+from construct import If
+from construct import IfThenElse
+from construct import Int16ub
+from construct import Int16ul
+from construct import Int32ub
+from construct import Int32ul
+from construct import Int64ub
+from construct import Int64ul
+from construct import Int8ul
+from construct import Padding
+from construct import Struct
+from construct import Switch
+from construct import this
+
+
+NumericType = (int, float)
+MtaType = namedtuple("MtaType", "address ext")
+
+
+class XcpGetIdType(enum.IntEnum):
+    ASCII_TEXT = 0
+    FILENAME = 1
+    FILE_AND_PATH = 2
+    URL = 3
+    FILE_TO_UPLOAD = 4
+    EPK = 5
+    ECU = 6
+    SYSID = 7
+    # Extensions by Vector Informatik.
+    VECTOR_MAPNAMES = 0xDB
+    VECTOR_MDI = 0xDC
+
+
+class Command(enum.IntEnum):
+
+    # STD
+
+    # Mandatory Commands
+    CONNECT = 0xFF
+    DISCONNECT = 0xFE
+    GET_STATUS = 0xFD
+    SYNCH = 0xFC
+
+    # Optional Commands
+    GET_COMM_MODE_INFO = 0xFB
+    GET_ID = 0xFA
+    SET_REQUEST = 0xF9
+    GET_SEED = 0xF8
+    UNLOCK = 0xF7
+    SET_MTA = 0xF6
+    UPLOAD = 0xF5
+    SHORT_UPLOAD = 0xF4
+    BUILD_CHECKSUM = 0xF3
+    TRANSPORT_LAYER_CMD = 0xF2
+    USER_CMD = 0xF1
+    GET_VERSION = 0xC000
+
+    # CAL
+
+    # Mandatory Commands
+    DOWNLOAD = 0xF0
+
+    # Optional Commands
+    DOWNLOAD_NEXT = 0xEF
+    DOWNLOAD_MAX = 0xEE
+    SHORT_DOWNLOAD = 0xED
+    MODIFY_BITS = 0xEC
+
+    # PAG
+
+    # Mandatory Commands
+    SET_CAL_PAGE = 0xEB
+    GET_CAL_PAGE = 0xEA
+
+    # Optional Commands
+    GET_PAG_PROCESSOR_INFO = 0xE9
+    GET_SEGMENT_INFO = 0xE8
+    GET_PAGE_INFO = 0xE7
+    SET_SEGMENT_MODE = 0xE6
+    GET_SEGMENT_MODE = 0xE5
+    COPY_CAL_PAGE = 0xE4
+
+    # DAQ
+
+    # Mandatory Commands
+    CLEAR_DAQ_LIST = 0xE3
+    SET_DAQ_PTR = 0xE2
+    WRITE_DAQ = 0xE1
+    WRITE_DAQ_MULTIPLE = 0xC7
+    SET_DAQ_LIST_MODE = 0xE0
+    GET_DAQ_LIST_MODE = 0xDF
+    START_STOP_DAQ_LIST = 0xDE
+    START_STOP_SYNCH = 0xDD
+
+    # Optional Commands
+    GET_DAQ_CLOCK = 0xDC
+    READ_DAQ = 0xDB
+    GET_DAQ_PROCESSOR_INFO = 0xDA
+    GET_DAQ_RESOLUTION_INFO = 0xD9
+    GET_DAQ_LIST_INFO = 0xD8
+    GET_DAQ_EVENT_INFO = 0xD7
+    DTO_CTR_PROPERTIES = 0xC5
+    SET_DAQ_PACKED_MODE = 0xC001
+    GET_DAQ_PACKED_MODE = 0xC002
+    FREE_DAQ = 0xD6
+    ALLOC_DAQ = 0xD5
+    ALLOC_ODT = 0xD4
+    ALLOC_ODT_ENTRY = 0xD3
+
+    # PGM
+
+    # Mandatory Commands
+    PROGRAM_START = 0xD2
+    PROGRAM_CLEAR = 0xD1
+    PROGRAM = 0xD0
+    PROGRAM_RESET = 0xCF
+
+    # Optional Commands
+    GET_PGM_PROCESSOR_INFO = 0xCE
+    GET_SECTOR_INFO = 0xCD
+    PROGRAM_PREPARE = 0xCC
+    PROGRAM_FORMAT = 0xCB
+    PROGRAM_NEXT = 0xCA
+    PROGRAM_MAX = 0xC9
+    PROGRAM_VERIFY = 0xC8
+
+    TIME_CORRELATION_PROPERTIES = 0xC6
+
+    # DBG
+
+    DBG_ATTACH = 0xC0FC00
+    DBG_GET_VENDOR_INFO = 0xC0FC01
+    DBG_GET_MODE_INFO = 0xC0FC02
+    DBG_GET_JTAG_ID = 0xC0FC03
+    DBG_HALT_AFTER_RESET = 0xC0FC04
+    DBG_GET_HWIO_INFO = 0xC0FC05
+    DBG_SET_HWIO_EVENT = 0xC0FC06
+    DBG_HWIO_CONTROL = 0xC0FC07
+    DBG_EXCLUSIVE_TARGET_ACCESS = 0xC0FC08
+    DBG_SEQUENCE_MULTIPLE = 0xC0FC09
+    DBG_LLT = 0xC0FC0A
+    DBG_READ_MODIFY_WRITE = 0xC0FC0B
+    DBG_WRITE = 0xC0FC0C
+    DBG_WRITE_NEXT = 0xC0FC0D
+    DBG_WRITE_CAN1 = 0xC0FC0E
+    DBG_WRITE_CAN2 = 0xC0FC0F
+    DBG_WRITE_CAN_NEXT = 0xC0FC10
+    DBG_READ = 0xC0FC11
+    DBG_READ_CAN1 = 0xC0FC12
+    DBG_READ_CAN2 = 0xC0FC13
+    DBG_GET_TRI_DESC_TBL = 0xC0FC14
+    DBG_LLBT = 0xC0FC15
+
+
+class CommandCategory(enum.IntEnum):
+    """Values reflect resources (resource protection status / unlock)."""
+
+    STD = 0
+    CAL_PAG = 1
+    DAQ = 4
+    STIM = 8
+    PGM = 16
+
+
+COMMAND_CATEGORIES = {  # Mainly needed to automatically UNLOCK.
+    Command.CONNECT: CommandCategory.STD,
+    Command.DISCONNECT: CommandCategory.STD,
+    Command.GET_STATUS: CommandCategory.STD,
+    Command.SYNCH: CommandCategory.STD,
+    Command.GET_COMM_MODE_INFO: CommandCategory.STD,
+    Command.GET_ID: CommandCategory.STD,
+    Command.SET_REQUEST: CommandCategory.STD,
+    Command.GET_SEED: CommandCategory.STD,
+    Command.UNLOCK: CommandCategory.STD,
+    Command.SET_MTA: CommandCategory.STD,
+    Command.UPLOAD: CommandCategory.STD,
+    Command.SHORT_UPLOAD: CommandCategory.STD,
+    Command.BUILD_CHECKSUM: CommandCategory.STD,
+    Command.TRANSPORT_LAYER_CMD: CommandCategory.STD,
+    Command.USER_CMD: CommandCategory.STD,
+    Command.GET_VERSION: CommandCategory.STD,
+    Command.DOWNLOAD: CommandCategory.CAL_PAG,
+    Command.DOWNLOAD_NEXT: CommandCategory.CAL_PAG,
+    Command.DOWNLOAD_MAX: CommandCategory.CAL_PAG,
+    Command.SHORT_DOWNLOAD: CommandCategory.CAL_PAG,
+    Command.MODIFY_BITS: CommandCategory.CAL_PAG,
+    Command.SET_CAL_PAGE: CommandCategory.CAL_PAG,
+    Command.GET_CAL_PAGE: CommandCategory.CAL_PAG,
+    Command.GET_PAG_PROCESSOR_INFO: CommandCategory.CAL_PAG,
+    Command.GET_SEGMENT_INFO: CommandCategory.CAL_PAG,
+    Command.GET_PAGE_INFO: CommandCategory.CAL_PAG,
+    Command.SET_SEGMENT_MODE: CommandCategory.CAL_PAG,
+    Command.GET_SEGMENT_MODE: CommandCategory.CAL_PAG,
+    Command.COPY_CAL_PAGE: CommandCategory.CAL_PAG,
+    Command.CLEAR_DAQ_LIST: CommandCategory.DAQ,
+    Command.SET_DAQ_PTR: CommandCategory.DAQ,
+    Command.WRITE_DAQ: CommandCategory.DAQ,
+    Command.WRITE_DAQ_MULTIPLE: CommandCategory.DAQ,
+    Command.SET_DAQ_LIST_MODE: CommandCategory.DAQ,
+    Command.GET_DAQ_LIST_MODE: CommandCategory.DAQ,
+    Command.START_STOP_DAQ_LIST: CommandCategory.DAQ,
+    Command.START_STOP_SYNCH: CommandCategory.DAQ,
+    Command.GET_DAQ_CLOCK: CommandCategory.DAQ,
+    Command.READ_DAQ: CommandCategory.DAQ,
+    Command.GET_DAQ_PROCESSOR_INFO: CommandCategory.DAQ,
+    Command.GET_DAQ_RESOLUTION_INFO: CommandCategory.DAQ,
+    Command.GET_DAQ_LIST_INFO: CommandCategory.DAQ,
+    Command.GET_DAQ_EVENT_INFO: CommandCategory.DAQ,
+    Command.DTO_CTR_PROPERTIES: CommandCategory.DAQ,
+    Command.SET_DAQ_PACKED_MODE: CommandCategory.DAQ,
+    Command.GET_DAQ_PACKED_MODE: CommandCategory.DAQ,
+    Command.FREE_DAQ: CommandCategory.DAQ,
+    Command.ALLOC_DAQ: CommandCategory.DAQ,
+    Command.ALLOC_ODT: CommandCategory.DAQ,
+    Command.ALLOC_ODT_ENTRY: CommandCategory.DAQ,
+    Command.PROGRAM_START: CommandCategory.PGM,
+    Command.PROGRAM_CLEAR: CommandCategory.PGM,
+    Command.PROGRAM: CommandCategory.PGM,
+    Command.PROGRAM_RESET: CommandCategory.PGM,
+    Command.GET_PGM_PROCESSOR_INFO: CommandCategory.PGM,
+    Command.GET_SECTOR_INFO: CommandCategory.PGM,
+    Command.PROGRAM_PREPARE: CommandCategory.PGM,
+    Command.PROGRAM_FORMAT: CommandCategory.PGM,
+    Command.PROGRAM_NEXT: CommandCategory.PGM,
+    Command.PROGRAM_MAX: CommandCategory.PGM,
+    Command.PROGRAM_VERIFY: CommandCategory.PGM,
+    # Well... ?
+    # TIME_CORRELATION_PROPERTIES
+}
+
+XcpError = Enum(
+    Int8ul,
+    ERR_CMD_SYNCH=0x00,  # Command processor synchronization. S0
+    ERR_CMD_BUSY=0x10,  # Command was not executed. S2
+    ERR_DAQ_ACTIVE=0x11,  # Command rejected because DAQ is running. S2
+    ERR_PGM_ACTIVE=0x12,  # Command rejected because PGM is running. S2
+    ERR_CMD_UNKNOWN=0x20,  # Unknown command or not implemented optional
+    # command. S2
+    ERR_CMD_SYNTAX=0x21,  # Command syntax invalid. S2
+    ERR_OUT_OF_RANGE=0x22,  # Command syntax valid but command parameter(s)
+    # out of range. S2
+    ERR_WRITE_PROTECTED=0x23,  # The memory location is write protected. S2
+    ERR_ACCESS_DENIED=0x24,  # The memory location is not accessible. S2
+    ERR_ACCESS_LOCKED=0x25,  # Access denied, Seed & Key is required. S2
+    ERR_PAGE_NOT_VALID=0x26,  # Selected page not available. S2
+    ERR_MODE_NOT_VALID=0x27,  # Selected page mode not available. S2
+    ERR_SEGMENT_NOT_VALID=0x28,  # Selected segment not valid. S2
+    ERR_SEQUENCE=0x29,  # Sequence error. S2
+    ERR_DAQ_CONFIG=0x2A,  # DAQ configuration not valid. S2
+    ERR_MEMORY_OVERFLOW=0x30,  # Memory overflow error. S2
+    ERR_GENERIC=0x31,  # Generic error. S2
+    ERR_VERIFY=0x32,  # The slave internal program verify routine detects an
+    # error. S3
+    # NEW IN 1.1
+    ERR_RESOURCE_TEMPORARY_NOT_ACCESSIBLE=0x33,
+    # Access to the requested resource is temporary not possible. S3
+    ERR_TIMEOUT=0xFF,  # Used by errorhandler; not an offical errorcode.
+)
+
+
+class Event(enum.IntEnum):
+    """XCP Event Codes"""
+
+    EV_RESUME_MODE = 0x00
+    EV_CLEAR_DAQ = 0x01
+    EV_STORE_DAQ = 0x02
+    EV_STORE_CAL = 0x03
+    EV_CMD_PENDING = 0x05
+    EV_DAQ_OVERLOAD = 0x06
+    EV_SESSION_TERMINATED = 0x07
+    EV_TIME_SYNC = 0x08
+    EV_STIM_TIMEOUT = 0x09
+    EV_SLEEP = 0x0A
+    EV_WAKE_UP = 0x0B
+    EV_USER = 0xFE
+    EV_TRANSPORT = 0xFF
+
+
+Response = Struct(
+    "type"
+    / Enum(
+        Int8ul,
+        OK=0xFF,
+        ERR=0xFE,
+        EV=0xFD,
+        SERV=0xFC,
+    )
+)
+
+DAQ = Struct(
+    "odt" / Int8ul,
+    "daq" / Int8ul,
+    "data" / GreedyBytes,
+)
+
+ResourceType = BitStruct(
+    Padding(2),
+    "dbg" / Flag,
+    "pgm" / Flag,
+    "stim" / Flag,
+    "daq" / Flag,
+    Padding(1),
+    "calpag" / Flag,
+)
+
+RESOURCE_VALUES = {
+    "dbg": 32,
+    "pgm": 16,
+    "stim": 8,
+    "daq": 4,
+    "calpag": 1,
+}
+
+AddressGranularity = Enum(
+    BitsInteger(2), BYTE=0b00, WORD=0b01, DWORD=0b10, RESERVED=0b11
+)
+
+ByteOrder = Enum(BitsInteger(1), INTEL=0, MOTOROLA=1)
+
+# byte-order dependent types
+Int16u = IfThenElse(this._.byteOrder == ByteOrder.INTEL, Int16ul, Int16ub)
+Int32u = IfThenElse(this._.byteOrder == ByteOrder.INTEL, Int32ul, Int32ub)
+Int64u = IfThenElse(this._.byteOrder == ByteOrder.INTEL, Int64ul, Int64ub)
+
+CommModeBasic = BitStruct(
+    "optional" / Flag,  # The OPTIONAL flag indicates whether additional
+    # information on supported types of Communication mode
+    # is available. The master can get that additional
+    # information with GET_COMM_MODE_INFO
+    "slaveBlockMode" / Flag,
+    Padding(3),
+    "addressGranularity" / AddressGranularity,
+    "byteOrder" / ByteOrder,
+)
+
+ConnectResponsePartial = Struct(
+    "resource" / ResourceType, "commModeBasic" / CommModeBasic
+)
+
+ConnectResponse = Struct(
+    "resource" / ResourceType,
+    "commModeBasic" / CommModeBasic,
+    "maxCto" / Int8ul,
+    "maxDto" / Int16u,
+    "protocolLayerVersion" / Int8ul,
+    "transportLayerVersion" / Int8ul,
+)
+
+GetVersionResponse = Struct(
+    Padding(1),
+    "protocolMajor" / Int8ul,
+    "protocolMinor" / Int8ul,
+    "transportMajor" / Int8ul,
+    "transportMinor" / Int8ul,
+)
+
+SessionStatus = BitStruct(
+    "resume" / Flag,
+    "daqRunning" / Flag,
+    Padding(2),
+    "clearDaqRequest" / Flag,
+    "storeDaqRequest" / Flag,
+    Padding(1),
+    "storeCalRequest" / Flag,
+)
+
+GetStatusResponse = Struct(
+    "sessionStatus" / SessionStatus,
+    "resourceProtectionStatus" / ResourceType,
+    Padding(1),
+    "sessionConfiguration" / Int16u,
+)
+
+CommModeOptional = BitStruct(
+    Padding(6),
+    "interleavedMode" / Flag,
+    "masterBlockMode" / Flag,
+)
+
+GetCommModeInfoResponse = Struct(
+    Padding(1),
+    "commModeOptional" / CommModeOptional,
+    Padding(1),
+    "maxBs" / Int8ul,
+    "minSt" / Int8ul,
+    "queueSize" / Int8ul,
+    "xcpDriverVersionNumber" / Int8ul,
+)
+
+GetIDResponse = Struct(
+    "mode" / Int8ul,
+    Padding(2),
+    "length" / Int32u,
+    "identification" / If(this.mode == 1, Int8ul[this.length]),
+)
+
+GetSeedResponse = Struct(
+    "length" / Int8ul, "seed" / If(this.length > 0, Int8ul[this.length])
+)
+
+SetRequestMode = BitStruct(
+    Padding(4),
+    "clearDaqReq" / Flag,
+    "storeDaqReq" / Flag,
+    Padding(1),
+    "storeCalReq" / Flag,
+)
+
+BuildChecksumResponse = Struct(
+    "checksumType"
+    / Enum(
+        Int8ul,
+        XCP_NONE=0x00,
+        XCP_ADD_11=0x01,
+        XCP_ADD_12=0x02,
+        XCP_ADD_14=0x03,
+        XCP_ADD_22=0x04,
+        XCP_ADD_24=0x05,
+        XCP_ADD_44=0x06,
+        XCP_CRC_16=0x07,
+        XCP_CRC_16_CITT=0x08,
+        XCP_CRC_32=0x09,
+        XCP_USER_DEFINED=0xFF,
+    ),
+    Padding(2),
+    "checksum" / Int32u,
+)
+
+SetCalPageMode = BitStruct(
+    "all" / Flag,
+    Padding(5),
+    "xcp" / Flag,
+    "ecu" / Flag,
+)
+
+GetPagProcessorInfoResponse = Struct(
+    "maxSegments" / Int8ul,
+    "pagProperties" / Int8ul,
+)
+
+GetSegmentInfoMode0Response = Struct(
+    Padding(3),
+    "basicInfo" / Int32u,
+)
+
+GetSegmentInfoMode1Response = Struct(
+    "maxPages" / Int8ul,
+    "addressExtension" / Int8ul,
+    "maxMapping" / Int8ul,
+    "compressionMethod" / Int8ul,
+    "encryptionMethod" / Int8ul,
+)
+
+GetSegmentInfoMode2Response = Struct(
+    Padding(3),
+    "mappingInfo" / Int32u,
+)
+
+PageProperties = BitStruct(
+    Padding(2),
+    "xcpWriteAccessWithEcu" / Flag,
+    "xcpWriteAccessWithoutEcu" / Flag,
+    "xcpReadAccessWithEcu" / Flag,
+    "xcpReadAccessWithoutEcu" / Flag,
+    "ecuAccessWithXcp" / Flag,
+    "ecuAccessWithoutXcp" / Flag,
+)
+
+DaqProperties = BitStruct(
+    "overloadEvent" / Flag,
+    "overloadMsb" / Flag,
+    "pidOffSupported" / Flag,
+    "timestampSupported" / Flag,
+    "bitStimSupported" / Flag,
+    "resumeSupported" / Flag,
+    "prescalerSupported" / Flag,
+    "daqConfigType" / Enum(BitsInteger(1), STATIC=0b0, DYNAMIC=0b1),
+)
+
+GetDaqProcessorInfoResponse = Struct(
+    "daqProperties" / DaqProperties,
+    "maxDaq" / Int16u,
+    "maxEventChannel" / Int16u,
+    "minDaq" / Int8ul,
+    "daqKeyByte"
+    / BitStruct(
+        "Identification_Field"
+        / Enum(
+            BitsInteger(2),
+            IDF_ABS_ODT_NUMBER=0b00,
+            IDF_REL_ODT_NUMBER_ABS_DAQ_LIST_NUMBER_BYTE=0b01,
+            IDF_REL_ODT_NUMBER_ABS_DAQ_LIST_NUMBER_WORD=0b10,
+            IDF_REL_ODT_NUMBER_ABS_DAQ_LIST_NUMBER_WORD_ALIGNED=0b11,
+        ),
+        "Address_Extension"
+        / Enum(
+            BitsInteger(2),
+            AE_DIFFERENT_WITHIN_ODT=0b00,
+            AE_SAME_FOR_ALL_ODT=0b01,
+            _NOT_ALLOWED=0b10,
+            AE_SAME_FOR_ALL_DAQ=0b11,
+        ),
+        "Optimisation_Type"
+        / Enum(
+            BitsInteger(4),
+            OM_DEFAULT=0b0000,
+            OM_ODT_TYPE_16=0b0001,
+            OM_ODT_TYPE_32=0b0010,
+            OM_ODT_TYPE_64=0b0011,
+            OM_ODT_TYPE_ALIGNMENT=0b0100,
+            OM_MAX_ENTRY_SIZE=0b0101,
+        ),
+    ),
+)
+
+DAQ_DIRECTION = Enum(BitsInteger(1), DAQ=0, STIM=1)
+
+PID_OFF = Enum(BitsInteger(1), DTO_WITH_ID_FIELD=0, DTO_WITHOUT_ID_FIELD=1)
+
+CurrentMode = BitStruct(
+    "resume" / Flag,
+    "running" / Flag,
+    "pid_off" / PID_OFF,
+    "timestamp" / Flag,
+    Padding(2),
+    "direction" / DAQ_DIRECTION,
+    "selected" / Flag,
+)
+
+GetDaqListModeResponse = Struct(
+    "currentMode" / CurrentMode,
+    Padding(2),
+    "currentEventChannel" / Int16u,
+    "currentPrescaler" / Int8ul,
+    "currentPriority" / Int8ul,
+)
+
+SetDaqListMode = BitStruct(
+    Padding(2),
+    "pid_off" / PID_OFF,
+    "enable_timestamp" / Flag,
+    Padding(2),
+    "direction" / DAQ_DIRECTION,
+    Padding(1),
+)
+
+DaqElement = Struct(
+    "bitOffset" / Int8ul,
+    "size" / Int8ul,
+    "address" / Int32u,
+    "addressExt" / Int8ul,
+    Padding(1),
+)
+
+GetDaqClockResponse = Struct(
+    Padding(3),
+    "timestamp" / Int32u,
+)
+
+DaqPackedMode = Enum(Int8ul, NONE=0, ELEMENT_GROUPED=1, EVENT_GROUPED=2)
+
+GetDaqPackedModeResponse = Struct(
+    Padding(1),
+    "daqPackedMode" / DaqPackedMode,
+    "dpmTimestampMode"
+    / If(
+        (this.daqPackedMode == "ELEMENT_GROUPED")
+        | (this.daqPackedMode == "EVENT_GROUPED"),
+        Int8ul,
+    ),
+    "dpmSampleCount"
+    / If(
+        (this.daqPackedMode == "ELEMENT_GROUPED")
+        | (this.daqPackedMode == "EVENT_GROUPED"),
+        Int16u,
+    ),
+)
+
+ReadDaqResponse = Struct(
+    "bitOffset" / Int8ul,
+    "sizeofDaqElement" / Int8ul,
+    "adressExtension" / Int8ul,
+    "address" / Int32u,
+)
+
+DaqTimestampUnit = Enum(
+    BitsInteger(4),
+    DAQ_TIMESTAMP_UNIT_1NS=0b0000,
+    DAQ_TIMESTAMP_UNIT_10NS=0b0001,
+    DAQ_TIMESTAMP_UNIT_100NS=0b0010,
+    DAQ_TIMESTAMP_UNIT_1US=0b0011,
+    DAQ_TIMESTAMP_UNIT_10US=0b0100,
+    DAQ_TIMESTAMP_UNIT_100US=0b0101,
+    DAQ_TIMESTAMP_UNIT_1MS=0b0110,
+    DAQ_TIMESTAMP_UNIT_10MS=0b0111,
+    DAQ_TIMESTAMP_UNIT_100MS=0b1000,
+    DAQ_TIMESTAMP_UNIT_1S=0b1001,
+    DAQ_TIMESTAMP_UNIT_1PS=0b1010,
+    DAQ_TIMESTAMP_UNIT_10PS=0b1011,
+    DAQ_TIMESTAMP_UNIT_100PS=0b1100,
+)
+
+GetDaqResolutionInfoResponse = Struct(
+    "granularityOdtEntrySizeDaq" / Int8ul,
+    "maxOdtEntrySizeDaq" / Int8ul,
+    "granularityOdtEntrySizeStim" / Int8ul,
+    "maxOdtEntrySizeStim" / Int8ul,
+    "timestampMode"
+    / BitStruct(  # Int8ul,
+        "unit" / DaqTimestampUnit,
+        "fixed" / Flag,
+        "size"
+        / Enum(
+            BitsInteger(3),
+            NO_TIME_STAMP=0b000,
+            S1=0b001,
+            S2=0b010,
+            NOT_ALLOWED=0b011,
+            S4=0b100,
+        ),
+    ),
+    "timestampTicks" / Int16u,
+)
+
+DaqListProperties = BitStruct(
+    Padding(3),
+    "packed" / Flag,
+    "stim" / Flag,
+    "daq" / Flag,
+    "eventFixed" / Flag,
+    "predefined" / Flag,
+)
+
+GetDaqListInfoResponse = Struct(
+    "daqListProperties" / DaqListProperties,
+    "maxOdt" / Int8ul,
+    "maxOdtEntries" / Int8ul,
+    "fixedEvent" / Int16u,
+)
+
+StartStopDaqListResponse = Struct("firstPid" / Int8ul)
+
+DaqEventProperties = BitStruct(
+    "consistency"
+    / Enum(
+        BitsInteger(2),
+        CONSISTENCY_ODT=0b00,
+        CONSISTENCY_DAQ=0b01,
+        CONSISTENCY_EVENTCHANNEL=0b10,
+        CONSISTENCY_NONE=0b11,
+    ),
+    Padding(1),
+    "packed" / Flag,
+    "stim" / Flag,
+    "daq" / Flag,
+    Padding(2),
+)
+
+GetEventChannelInfoResponse = Struct(
+    "daqEventProperties" / DaqEventProperties,
+    "maxDaqList" / Int8ul,
+    "eventChannelNameLength" / Int8ul,
+    "eventChannelTimeCycle" / Int8ul,
+    "eventChannelTimeUnit"
+    / Enum(
+        Int8ul,
+        EVENT_CHANNEL_TIME_UNIT_1NS=0,
+        EVENT_CHANNEL_TIME_UNIT_10NS=1,
+        EVENT_CHANNEL_TIME_UNIT_100NS=2,
+        EVENT_CHANNEL_TIME_UNIT_1US=3,
+        EVENT_CHANNEL_TIME_UNIT_10US=4,
+        EVENT_CHANNEL_TIME_UNIT_100US=5,
+        EVENT_CHANNEL_TIME_UNIT_1MS=6,
+        EVENT_CHANNEL_TIME_UNIT_10MS=7,
+        EVENT_CHANNEL_TIME_UNIT_100MS=8,
+        EVENT_CHANNEL_TIME_UNIT_1S=9,
+        EVENT_CHANNEL_TIME_UNIT_1PS=10,
+        EVENT_CHANNEL_TIME_UNIT_10PS=11,
+        EVENT_CHANNEL_TIME_UNIT_100PS=12,
+    ),
+    "eventChannelPriority" / Int8ul,
+)
+
+DtoCtrProperties = BitStruct(
+    "evtCtrPresent" / Flag,
+    "stimCtrCpyPresent" / Flag,
+    "stimModePresent" / Flag,
+    "daqModePresent" / Flag,
+    "relatedEventPresent" / Flag,
+    "stimModeFixed" / Flag,
+    "daqModeFixed" / Flag,
+    "relatedEventFixed" / Flag,
+)
+
+DtoCtrMode = BitStruct(Padding(6), "stimMode" / Flag, "daqMode" / Flag)
+
+DtoCtrPropertiesResponse = Struct(
+    "properties" / DtoCtrProperties, "relatedEventChannel" / Int16u, "mode" / DtoCtrMode
+)
+
+CommModePgm = BitStruct(
+    Padding(1),
+    "slaveBlockMode" / Flag,
+    Padding(4),
+    "interleavedMode" / Flag,
+    "masterBlockMode" / Flag,
+)
+
+ProgramStartResponse = Struct(
+    Padding(1),
+    "commModePgm" / CommModePgm,
+    "maxCtoPgm" / Int8ul,
+    "maxBsPgm" / Int8ul,
+    "minStPgm" / Int8ul,
+    "queueSizePgm" / Int8ul,
+)
+
+PgmProperties = BitStruct(
+    "nonSeqPgmRequired" / Flag,
+    "nonSeqPgmSupported" / Flag,
+    "encryptionRequired" / Flag,
+    "encryptionSupported" / Flag,
+    "compressionRequired" / Flag,
+    "compressionSupported" / Flag,
+    "functionalMode" / Flag,
+    "absoluteMode" / Flag,
+)
+
+GetPgmProcessorInfoResponse = Struct(
+    "pgmProperties" / PgmProperties, "maxSector" / Int8ul
+)
+
+GetSectorInfoResponseMode01 = Struct(
+    "clearSequenceNumber" / Int8ul,
+    "programSequenceNumber" / Int8ul,
+    "programmingMethod" / Int8ul,
+    "sectorInfo" / Int32u,
+)
+
+GetSectorInfoResponseMode2 = Struct("sectorNameLength" / Int8ul)
+
+TimeCorrelationPropertiesResponse = Struct(
+    "slaveConfig" / Int8ul,
+    "observableClocks" / Int8ul,
+    "syncState" / Int8ul,
+    "clockInfo" / Int8ul,
+    Padding(1),
+    "clusterId" / Int16u,
+)
+
+DaqPtr = namedtuple("DaqPtr", "daqListNumber odtNumber odtEntryNumber")
+
+DbgAttachResponse = Struct(
+    "major" / Int8ul,
+    "minor" / Int8ul,
+    "timeout1" / Int8ul,
+    "timeout7" / Int8ul,
+    Padding(1),
+    "maxCtoDbg" / Int16u,
+)
+
+DbgGetVendorInfoResponse = Struct(
+    "length" / Int8ul,
+    "vendorId" / Int16u,
+    "vendorInfo" / Int8ul[this.length],
+)
+
+DbgGetModeInfoResponse = Struct(
+    Padding(1),
+    "maxHwIoPins" / Int8ul,
+    "dialect" / Int8ul,
+    "feature" / Int8ul,
+    "serviceLevel" / Int8ul,
+)
+
+DbgGetJtagIdResponse = Struct(
+    Padding(3),
+    "jtagId" / Int32u,
+)
+
+DbgGetHwioInfoPin = Struct(
+    "index" / Int8ul,
+    "mode" / Int8ul,
+    "pinClass" / Int8ul,
+    "state" / Int8ul,
+)
+
+DbgGetHwioInfoResponse = Struct(
+    "num" / Int8ul,
+    "pins" / DbgGetHwioInfoPin[this.num],
+)
+
+DbgHwioControlResponse = GreedyBytes
+
+DbgSequenceMultipleResult = Struct(
+    "status" / Int8ul,
+    "repeat" / Int8ul,
+    "tdo" / Int32ub,
+)
+
+DbgSequenceMultipleResponse = Struct(
+    Padding(1),
+    "num" / Int8ul,
+    "results" / DbgSequenceMultipleResult[this.num],
+)
+
+DbgLltResult = Struct(
+    "length" / Int8ul,
+    "data" / Int8ul[this.length // 8],
+)
+
+DbgLltResponse = Struct(
+    "num" / Int8ul,
+    "results" / DbgLltResult[this.num],
+)
+
+DbgReadModifyWriteResponse = Struct(
+    If(this._.width == 2, Padding(1)),
+    If(this._.width == 4, Padding(3)),
+    If(this._.width == 8, Padding(7)),
+    "value" / Switch(this._.width, {1: Int8ul, 2: Int16u, 4: Int32u, 8: Int64u}),
+)
+
+DbgReadResponse = Struct(
+    If(this._.width == 2, Padding(1)),
+    If(this._.width == 4, Padding(3)),
+    If(this._.width == 8, Padding(7)),
+    "data"
+    / GreedyRange(Switch(this._.width, {1: Int8ul, 2: Int16u, 4: Int32u, 8: Int64u})),
+)
+
+DbgGetTriDescTblTrad = Struct(
+    "trai" / Int64ul,
+    "trdt" / Int16ul,
+    "trat" / Int16ul,
+    Padding(4),
+)
+
+DbgGetTriDescTblTri = Struct(
+    "tri" / Int8ul,
+    "trad_cnt" / Int8ul,
+    Padding(6),
+    "trads" / DbgGetTriDescTblTrad[this.trad_cnt],
+)
+
+DbgGetTriDescTbl = Struct(
+    "tri_cnt" / Int8ul, Padding(7), "tris" / DbgGetTriDescTblTri[this.tri_cnt]
+)
+
+DbgGetTriDescTblResponse = Struct(
+    "mode" / Int8ul, Padding(2), "length" / Int32u, "table" / DbgGetTriDescTbl
+)
+
+DbgLlbtResponse = Struct(Padding(1), "length" / Int16u, "data" / Int8ul[this.length])
+
+DAQ_TIMESTAMP_UNIT_TO_EXP = {
+    "DAQ_TIMESTAMP_UNIT_1PS": -12,
+    "DAQ_TIMESTAMP_UNIT_10PS": -11,
+    "DAQ_TIMESTAMP_UNIT_100PS": -10,
+    "DAQ_TIMESTAMP_UNIT_1NS": -9,
+    "DAQ_TIMESTAMP_UNIT_10NS": -8,
+    "DAQ_TIMESTAMP_UNIT_100NS": -7,
+    "DAQ_TIMESTAMP_UNIT_1US": -6,
+    "DAQ_TIMESTAMP_UNIT_10US": -5,
+    "DAQ_TIMESTAMP_UNIT_100US": -4,
+    "DAQ_TIMESTAMP_UNIT_1MS": -3,
+    "DAQ_TIMESTAMP_UNIT_10MS": -2,
+    "DAQ_TIMESTAMP_UNIT_100MS": -1,
+    "DAQ_TIMESTAMP_UNIT_1S": 0,
+}
+
+
+class XcpGetSeedMode(enum.IntEnum):
+    FIRST_PART = 0
+    REMAINING = 1


### PR DESCRIPTION
This file is the only module we use. Since pyxcp has a complex build
system we can avoid any errors in the CI pipeline by copying this file. The
reuse tool ensures correct license tagging.
