### PR TITLE
feat: Implement color and terminal stuff with `rich`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -220,6 +220,17 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "commonmark"
+version = "0.9.1"
+description = "Python parser for the CommonMark Markdown spec"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.extras]
+test = ["flake8 (==3.7.8)", "hypothesis (==3.55.3)"]
+
+[[package]]
 name = "construct"
 version = "2.10.68"
 description = "A powerful declarative symmetric parser/builder for binary data"
@@ -604,7 +615,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 name = "pygments"
 version = "2.12.0"
 description = "Pygments is a syntax highlighting package written in Python."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -860,6 +871,21 @@ Jinja2 = "*"
 license-expression = "*"
 python-debian = "*"
 requests = "*"
+
+[[package]]
+name = "rich"
+version = "12.4.4"
+description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
+category = "main"
+optional = false
+python-versions = ">=3.6.3,<4.0.0"
+
+[package.dependencies]
+commonmark = ">=0.9.0,<0.10.0"
+pygments = ">=2.6.0,<3.0.0"
+
+[package.extras]
+jupyter = ["ipywidgets (>=7.5.1,<8.0.0)"]
 
 [[package]]
 name = "rope"
@@ -1135,7 +1161,7 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.9,<3.11"
-content-hash = "bd66b56deb42468130e029ddeab0ce894a4a82cf1596dc1d25b41cd2c301d474"
+content-hash = "a621b04fac6b90aea534ceedde03ac2e63ecc378e65421e83dac729f4137832a"
 
 [metadata.files]
 aiofiles = [
@@ -1356,6 +1382,10 @@ click = [
 colorama = [
     {file = "colorama-0.4.5-py2.py3-none-any.whl", hash = "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da"},
     {file = "colorama-0.4.5.tar.gz", hash = "sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4"},
+]
+commonmark = [
+    {file = "commonmark-0.9.1-py2.py3-none-any.whl", hash = "sha256:da2f38c92590f83de410ba1a3cbceafbc74fee9def35f9251ba9a971d6d66fd9"},
+    {file = "commonmark-0.9.1.tar.gz", hash = "sha256:452f9dc859be7f06631ddcb328b6919c67984aca654e5fefb3914d54691aed60"},
 ]
 construct = [
     {file = "construct-2.10.68.tar.gz", hash = "sha256:7b2a3fd8e5f597a5aa1d614c3bd516fa065db01704c72a1efaaeec6ef23d8b45"},
@@ -1865,6 +1895,10 @@ requests = [
 reuse = [
     {file = "reuse-1.0.0-py3-none-any.whl", hash = "sha256:e2605e796311c424465d741ea2a1e1ad03bbb90b921d74750119c331ca5af46e"},
     {file = "reuse-1.0.0.tar.gz", hash = "sha256:db3022be2d87f69c8f508b928023de3026f454ce17d01e22f770f7147ac1e8d4"},
+]
+rich = [
+    {file = "rich-12.4.4-py3-none-any.whl", hash = "sha256:d2bbd99c320a2532ac71ff6a3164867884357da3e3301f0240090c5d2fdac7ec"},
+    {file = "rich-12.4.4.tar.gz", hash = "sha256:4c586de507202505346f3e32d1363eb9ed6932f0c2f63184dea88983ff4971e2"},
 ]
 rope = [
     {file = "rope-1.1.1-py3-none-any.whl", hash = "sha256:216390b6342bde8ef1f27a6663554de0ea0b1fdad7c421deb3d5a3f6c5fc01e7"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ zstandard = ">=0.17,<0.19"
 python-can = "^4.0.0"
 tabulate = "^0.8.9"
 construct = "^2.10.68"
+rich = "^12.4.4"
 
 [tool.poetry.dev-dependencies]
 black = "^22.1.0"

--- a/src/gallia/utils.py
+++ b/src/gallia/utils.py
@@ -7,7 +7,6 @@ import re
 from argparse import Action, ArgumentError, ArgumentParser, Namespace
 from enum import Enum
 from pathlib import Path
-from sys import stdout
 from typing import TYPE_CHECKING, Any, Callable, Optional, Sequence, Union
 from urllib.parse import urlparse
 
@@ -183,30 +182,6 @@ async def catch_and_log_exception(
         return await func(*args, **kwargs)
     except Exception as e:
         logger.log_error(f"func {func.__name__} failed: {repr(e)}")
-
-
-class ANSIEscapes:
-    if stdout.isatty():
-        BOLD = "\033[1m"
-        ITALIC = "\033[3m"
-        UNDERSCORE = "\033[4m"
-        BLINK = "\033[5m"
-        CROSSED = "\033[9m"
-
-        BLACK = "\033[90m"
-        RED = "\033[91m"
-        GREEN = "\033[92m"
-        YELLOW = "\033[93m"
-        BLUE = "\033[94m"
-        MAGENTA = "\033[95m"
-        CYAN = "\033[96m"
-        WHITE = "\033[97m"
-
-        RESET = "\033[0m"
-    else:
-        BOLD = ITALIC = UNDERSCORE = BLINK = CROSSED = ""
-        BLACK = RED = GREEN = YELLOW = BLUE = MAGENTA = CYAN = WHITE = ""
-        RESET = ""
 
 
 async def write_target_list(

--- a/src/penlog/__init__.py
+++ b/src/penlog/__init__.py
@@ -14,6 +14,10 @@ from datetime import datetime
 from enum import Enum, IntEnum
 from typing import Any, TextIO, Optional
 
+from rich.console import Console
+
+console = Console()
+
 
 class MessageType(str, Enum):
     MESSAGE = "message"
@@ -39,20 +43,6 @@ class OutputType(Enum):
     HR_NANO = "hr-nano"
 
 
-class Color(Enum):
-    NOP = ""
-    RESET = "\033[0m"
-    BOLD = "\033[1m"
-    RED = "\033[31m"
-    GREEN = "\033[32m"
-    YELLOW = "\033[33m"
-    BLUE = "\033[34m"
-    PURPLE = "\033[35m"
-    CYAN = "\033[36m"
-    WHITE = "\033[37m"
-    GRAY = "\033[0;38;5;245m"
-
-
 @dataclass
 class RecordType:
     component: str
@@ -65,12 +55,6 @@ class RecordType:
     line: Optional[str] = None
     stacktrace: Optional[str] = None
     tags: Optional[list[str]] = None
-
-
-def colorize(color: Color, s: str) -> str:
-    if color == Color.NOP:
-        return s
-    return f"{color.value}{s}{Color.RESET.value}"
 
 
 def _get_line_number(depth: int) -> str:


### PR DESCRIPTION
This lib https://rich.readthedocs.io/ does all the heavy lifting with detecting of terminal capabilities, detection of color systems, … We should just use it rather than implementing our own homebrewed terminal escape code stuff. This will help with the TUI as well which is scheduled in gallia v1.2.0.

It also supports progress bars: https://rich.readthedocs.io/en/latest/progress.html; #168 