### PR TITLE
fix: Raise a TimeoutError when wait_for_ecu() times out

### DIFF
--- a/src/gallia/uds/ecu.py
+++ b/src/gallia/uds/ecu.py
@@ -336,10 +336,7 @@ class ECU(UDSClient):
         """wait for ecu to be alive again (eg. after reset)
         Wait at most timeout"""
         t = timeout if timeout is not None else self.timeout
-        try:
-            await asyncio.wait_for(self._wait_for_ecu(t * 0.8), timeout=t)
-        except asyncio.TimeoutError:
-            self.logger.log_critical("Timeout while waiting for ECU!")
+        await asyncio.wait_for(self._wait_for_ecu(t * 0.8), timeout=t)
 
     async def update_state(
         self, request: service.UDSRequest, response: service.UDSResponse


### PR DESCRIPTION
Commit 8f225c7422599b2ce3a10b4c2d529608028ba6f7 removed the return value of `wait_for_ecu()`. This brakes a gallia plugin which we use internally. I think it makes more sense to just raise the `TimeoutError`. @fkglr any thoughts?