### PR TITLE
fix: Add accidentally removed return value of `wait_for_ecu()`

### DIFF
--- a/src/gallia/uds/ecu.py
+++ b/src/gallia/uds/ecu.py
@@ -332,14 +332,16 @@ class ECU(UDSClient):
     async def wait_for_ecu(
         self,
         timeout: Optional[float] = None,
-    ) -> None:
+    ) -> bool:
         """wait for ecu to be alive again (eg. after reset)
         Wait at most timeout"""
         t = timeout if timeout is not None else self.timeout
         try:
             await asyncio.wait_for(self._wait_for_ecu(t * 0.8), timeout=t)
+            return True
         except asyncio.TimeoutError:
             self.logger.log_critical("Timeout while waiting for ECU!")
+            return False
 
     async def update_state(
         self, request: service.UDSRequest, response: service.UDSResponse


### PR DESCRIPTION
In 8f225c7422599b2ce3a10b4c2d529608028ba6f7 I removed the return value of `wait_for_ecu()`. This brakes our internal plugins. Readd this for the next maintenance release. #195 is up for discussion, whether an exception is better.