### PR TITLE
feat(db): Add option to disable commit on every insert

### DIFF
--- a/src/gallia/db/db_handler.py
+++ b/src/gallia/db/db_handler.py
@@ -286,6 +286,7 @@ class DBHandler:
         send_time: datetime,
         receive_time: Optional[datetime],
         log_mode: LogMode,
+        commit: bool = True,
     ) -> None:
         assert self.connection is not None, "Not connected to the database"
         assert self.scan_run is not None, "Scan run not yet created"
@@ -374,6 +375,7 @@ class DBHandler:
                         f"Could not log message for {query_parameter[5]} to database. Retrying ..."
                     )
 
-            await self.connection.commit()
+            if commit:
+                await self.connection.commit()
 
         self.tasks.append(asyncio.create_task(execute()))


### PR DESCRIPTION
When doing bulk insert, committing on every row is very slow.
This PR makes the commit optional.
Commit is done at disconnect anyway.