### PR TITLE
fix(db): Update ecu state after reconnect

### DIFF
--- a/src/gallia/uds/core/client.py
+++ b/src/gallia/uds/core/client.py
@@ -42,7 +42,8 @@ class UDSClient:
         self.logger = Logger("uds", flush=True)
 
     async def reconnect(self, timeout: Optional[int] = None) -> None:
-        """Calls the underlying transport to trigger a reconnect"""
+        """Calls the underlying transport to trigger a reconnect.
+        Be aware, that this might change the state of the ECU! Always restore desired state after reconnect."""
         await self.transport.reconnect(timeout)
 
     async def _read(

--- a/src/gallia/udscan/scanner/fuzz_payloads.py
+++ b/src/gallia/udscan/scanner/fuzz_payloads.py
@@ -5,6 +5,7 @@
 import asyncio
 import binascii
 import random
+import sys
 from argparse import Namespace
 
 from gallia.transports.base import TargetURI
@@ -176,6 +177,11 @@ class FuzzPayloads(UDSScanner):
                         )
                         flow_control_miss += 1
                         await self.ecu.reconnect()
+                        if not self.ecu.check_and_set_session(session):
+                            self.logger.log_error(
+                                f"Could not change to session 0x{session:02x} after reconnect; exit"
+                            )
+                            sys.exit(1)
 
                 self.logger.log_summary(f"Scan in session 0x{session:0x} is complete!")
 

--- a/src/gallia/udscan/scanner/scan_services.py
+++ b/src/gallia/udscan/scanner/scan_services.py
@@ -4,6 +4,7 @@
 
 import asyncio
 import reprlib
+import sys
 from argparse import BooleanOptionalAction, Namespace
 from binascii import unhexlify
 from typing import Any
@@ -148,6 +149,11 @@ class ScanServices(UDSScanner):
                 except Exception as e:
                     self.logger.log_info(f"{g_repr(sid)}: {g_repr(e)} occurred")
                     await self.ecu.reconnect()
+                    if not self.ecu.check_and_set_session(session):
+                        self.logger.log_error(
+                            f"Could not change to session 0x{session:02x} after reconnect; exit"
+                        )
+                        sys.exit(1)
                     continue
 
                 if suggests_service_not_supported(resp):

--- a/src/gallia/udscan/scanner/scan_sessions.py
+++ b/src/gallia/udscan/scanner/scan_sessions.py
@@ -164,6 +164,11 @@ class IterateSessions(UDSScanner):
                                 "Attempting to reconnect…"
                             )
                             await self.ecu.reconnect()
+                            if not self.ecu.check_and_set_session(session):
+                                self.logger.log_error(
+                                    f"Could not change to session 0x{session:02x} after reconnect; exit"
+                                )
+                                sys.exit(1)
 
                     try:
                         resp = await self.ecu.set_session(0x01)


### PR DESCRIPTION
After reconnect, the ECU might have lost its state (eg. session).
This PR updates the state after the reconnect.