### PR TITLE
vecu: minor cleanups

### DIFF
--- a/src/gallia/uds/server.py
+++ b/src/gallia/uds/server.py
@@ -885,6 +885,7 @@ class TCPUDSServerTransport(UDSServerTransport):
 
                 if uds_response_raw is not None:
                     writer.write(b2a_hex(uds_response_raw) + b"\n")
+                    await writer.drain()
             except Exception:
                 traceback.print_exc()
 

--- a/src/gallia/uds/server.py
+++ b/src/gallia/uds/server.py
@@ -7,7 +7,7 @@ import json
 import random
 import traceback
 from abc import ABC, abstractmethod
-from binascii import b2a_hex, unhexlify
+from binascii import hexlify, unhexlify
 from copy import copy
 from pathlib import Path
 from time import time
@@ -884,7 +884,7 @@ class TCPUDSServerTransport(UDSServerTransport):
                 response_times.append(response_time)
 
                 if uds_response_raw is not None:
-                    writer.write(b2a_hex(uds_response_raw) + b"\n")
+                    writer.write(hexlify(uds_response_raw) + b"\n")
                     await writer.drain()
             except Exception:
                 traceback.print_exc()


### PR DESCRIPTION
- fix: Add missing writer.drain()

Asyncio's StreamWriter works like this: `.write()` writes to an internal buffer, `.drain()` writes the content of this buffer to the network. If you omit `.drain()` messages can be lost, since the runtime decides when the buffer is drained.

- fix: Use hexlify(), since its counterpart unhexlify() is already used

Just for consistency. `unhexlify()` is already used, so let's use its counterpart for better consistency.
