### PR TITLE
fix(commands): rename wmby to wmba

### DIFF
--- a/src/gallia/commands/primitive/uds/wmba.py
+++ b/src/gallia/commands/primitive/uds/wmba.py
@@ -15,7 +15,7 @@ from gallia.utils import auto_int, g_repr
 class WMBAPrimitive(UDSScanner):
     """Write memory by address"""
 
-    COMMAND = "wmby"
+    COMMAND = "wmba"
     CATEGORY = "primitive"
     SHORT_HELP = "WriteMemoryByAddress"
 


### PR DESCRIPTION
The name seems a little off compared to the naming scheme of the other primitives