### PR TITLE
fix(discovery): Output all addresses as hex in discovery results

### DIFF
--- a/src/gallia/commands/discover/uds/doip.py
+++ b/src/gallia/commands/discover/uds/doip.py
@@ -113,8 +113,8 @@ class DoIPDiscoverer(DiscoveryScanner):
             host,
             port,
             {
-                "src_addr": diag_msg.TargetAddress,
-                "dst_addr": diag_msg.SourceAddress,
+                "src_addr": hex(diag_msg.TargetAddress),
+                "dst_addr": hex(diag_msg.SourceAddress),
                 "activation_type": activation_type.value,
             },
         )

--- a/src/gallia/commands/discover/uds/isotp.py
+++ b/src/gallia/commands/discover/uds/isotp.py
@@ -218,8 +218,8 @@ class IsotpDiscoverer(DiscoveryScanner):
 
                         if args.extended_addr:
                             target_args["ext_address"] = hex(ID)
-                            target_args["rx_ext_address"] = args.tester_addr & 0xFF
-                            target_args["src_addr"] = args.tester_addr
+                            target_args["rx_ext_address"] = hex(args.tester_addr & 0xFF)
+                            target_args["src_addr"] = hex(args.tester_addr)
                             target_args["dst_addr"] = hex(addr)
                         else:
                             target_args["src_addr"] = hex(ID)


### PR DESCRIPTION
Quick fix for the currently mixed (hex, decimal) output for addresses of the discovery scanner results.