### PR TITLE
fix: Skip properties post when transport is closed

### DIFF
--- a/src/gallia/command.py
+++ b/src/gallia/command.py
@@ -635,7 +635,7 @@ class UDSScanner(Scanner):
                 )
 
     async def teardown(self, args: Namespace) -> None:
-        if args.properties is True:
+        if args.properties is True and not self.ecu.transport.is_closed:
             path = self.artifacts_dir.joinpath(FileNames.PROPERTIES_POST.value)
             async with aiofiles.open(path, "w") as file:
                 await file.write(json.dumps(await self.ecu.properties(True), indent=4))

--- a/src/gallia/transports/base.py
+++ b/src/gallia/transports/base.py
@@ -75,6 +75,7 @@ class BaseTransport(ABC):
         self.mutex = asyncio.Lock()
         self.logger = get_logger(self.SCHEME)
         self.target = target
+        self.is_closed = False
 
     def __init_subclass__(
         cls,

--- a/src/gallia/transports/doip.py
+++ b/src/gallia/transports/doip.py
@@ -563,6 +563,7 @@ class DoIPTransport(BaseTransport, scheme="doip"):
         return cls(t, port, config, conn)
 
     async def close(self) -> None:
+        self.is_closed = True
         await self._conn.close()
 
     async def read(

--- a/src/gallia/transports/tcp.py
+++ b/src/gallia/transports/tcp.py
@@ -34,6 +34,7 @@ class TCPTransport(BaseTransport, scheme="tcp"):
         return cls(t, reader, writer)
 
     async def close(self) -> None:
+        self.is_closed = True
         self.writer.close()
         await self.writer.wait_closed()
 


### PR DESCRIPTION
If the connection has been terminated, the properties could not be read.
