### PR TITLE
fix: Catch asyncio.CancelledError correctly in tester_present_worker

### DIFF
--- a/src/gallia/services/uds/ecu.py
+++ b/src/gallia/services/uds/ecu.py
@@ -384,8 +384,6 @@ class ECU(UDSClient):
                 break
             except Exception as e:
                 self.logger.debug(f"tester present got {g_repr(e)}")
-                # Wait until the stack recovers, but not for too long…
-                await asyncio.sleep(1)
 
     async def start_cyclic_tester_present(self, interval: float) -> None:
         self.tester_present_interval = interval


### PR DESCRIPTION
When the tasks was cancelled while waiting in this sleep, the
asyncio.CancelledError is not catched. Remove the useless sleep.
