### PR TITLE
fix: Do not raise an exception when piped to `head`

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: AISEC Pentesting Team
+
+SPDX-License-Identifier: CC0-1.0
+-->
+
 # Logging
 
 ## Concept

--- a/src/hr/__init__.py
+++ b/src/hr/__init__.py
@@ -78,7 +78,8 @@ def _main() -> int:
 def main() -> None:
     try:
         sys.exit(_main())
-    except KeyboardInterrupt:
+    # BrokenPipeError appears when stuff is piped to | head.
+    except (KeyboardInterrupt, BrokenPipeError):
         pass
 
 


### PR DESCRIPTION
Fixes #291 