### PR TITLE
fix: Remove circular import by moving g_repr into uds.core

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
     nixpkgs.url = "github:nixos/nixpkgs";
   };
 
-  outputs = { self, nixpkgs, poetry2nix }:
+  outputs = { self, nixpkgs }:
     with import nixpkgs { system = "x86_64-linux"; };
     let pkgs = nixpkgs.legacyPackages.x86_64-linux;
     in {

--- a/src/gallia/command/base.py
+++ b/src/gallia/command/base.py
@@ -29,7 +29,7 @@ from gallia.log import Loglevel, get_logger, setup_logging, tz
 from gallia.powersupply import PowerSupply, PowerSupplyURI
 from gallia.services.uds.core.exception import UDSException
 from gallia.transports import TargetURI
-from gallia.utils import camel_to_snake, g_repr
+from gallia.utils import camel_to_snake
 
 
 @unique
@@ -370,7 +370,7 @@ class BaseCommand(ABC):
             for t in self.CATCHED_EXCEPTIONS:
                 if isinstance(e, t):
                     exit_code = ExitCodes.GENERIC_ERROR
-                    self.logger.critical(g_repr(e))
+                    self.logger.critical(repr(e))
                     break
             else:
                 exit_code = ExitCodes.UNHANDLED_EXCEPTION
@@ -509,14 +509,14 @@ class Scanner(AsyncScript, ABC):
                     )
                 except Exception as e:
                     self.logger.warning(
-                        f"Could not write the run meta to the database: {g_repr(e)}"
+                        f"Could not write the run meta to the database: {e!r}"
                     )
 
             try:
                 await self.db_handler.disconnect()
             except Exception as e:
                 self.logger.error(
-                    f"Could not close the database connection properly: {g_repr(e)}"
+                    f"Could not close the database connection properly: {e!r}"
                 )
 
     async def setup(self, args: Namespace) -> None:

--- a/src/gallia/command/uds.py
+++ b/src/gallia/command/uds.py
@@ -14,7 +14,6 @@ from gallia.services.uds.core.service import NegativeResponse, UDSResponse
 from gallia.services.uds.ecu import ECU
 from gallia.services.uds.helpers import raise_for_error
 from gallia.transports import BaseTransport
-from gallia.utils import g_repr
 
 
 class UDSScanner(Scanner):
@@ -141,7 +140,7 @@ class UDSScanner(Scanner):
                 self._apply_implicit_logging_setting()
             except Exception as e:
                 self.logger.warning(
-                    f"Could not write the scan run to the database: {g_repr(e)}"
+                    f"Could not write the scan run to the database: {e:!r}"
                 )
 
         if args.ecu_reset is not None:
@@ -178,7 +177,7 @@ class UDSScanner(Scanner):
                 self._apply_implicit_logging_setting()
             except Exception as e:
                 self.logger.warning(
-                    f"Could not write the properties_pre to the database: {g_repr(e)}"
+                    f"Could not write the properties_pre to the database: {e!r}"
                 )
 
     async def teardown(self, args: Namespace) -> None:
@@ -202,7 +201,7 @@ class UDSScanner(Scanner):
                 )
             except Exception as e:
                 self.logger.warning(
-                    f"Could not write the scan run to the database: {g_repr(e)}"
+                    f"Could not write the scan run to the database: {e!r}"
                 )
 
         if args.tester_present:
@@ -235,5 +234,5 @@ class UDSDiscoveryScanner(Scanner):
                 await self.db_handler.insert_discovery_run(args.target.url.scheme)
             except Exception as e:
                 self.logger.warning(
-                    f"Could not write the discovery run to the database: {g_repr(e)}"
+                    f"Could not write the discovery run to the database: {e!r}"
                 )

--- a/src/gallia/commands/discover/uds/find_xcp.py
+++ b/src/gallia/commands/discover/uds/find_xcp.py
@@ -12,9 +12,9 @@ from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser, Namespace
 from subprocess import CalledProcessError, run
 
 from gallia.log import get_logger
-from gallia.services.uds.core.utils import bytes_repr
+from gallia.services.uds.core.utils import bytes_repr, g_repr
 from gallia.transports import RawCANTransport, TargetURI
-from gallia.utils import can_id_repr, g_repr
+from gallia.utils import can_id_repr
 
 
 class FindXCP:

--- a/src/gallia/commands/discover/uds/isotp.py
+++ b/src/gallia/commands/discover/uds/isotp.py
@@ -8,8 +8,9 @@ from binascii import unhexlify
 
 from gallia.command import UDSDiscoveryScanner
 from gallia.services.uds import NegativeResponse, UDSClient, UDSRequest
+from gallia.services.uds.core.utils import g_repr
 from gallia.transports import ISOTPTransport, RawCANTransport, TargetURI
-from gallia.utils import auto_int, can_id_repr, g_repr, write_target_list
+from gallia.utils import auto_int, can_id_repr, write_target_list
 
 
 class IsotpDiscoverer(UDSDiscoveryScanner):
@@ -112,7 +113,7 @@ class IsotpDiscoverer(UDSDiscoveryScanner):
                 else:
                     self.logger.result(f"response was: {resp}")
             except Exception as e:
-                self.logger.result(f"reading description failed: {g_repr(e)}")
+                self.logger.result(f"reading description failed: {e!r}")
 
     def _build_isotp_frame_extended(
         self,

--- a/src/gallia/commands/primitive/uds/dtc.py
+++ b/src/gallia/commands/primitive/uds/dtc.py
@@ -11,7 +11,8 @@ from tabulate import tabulate
 from gallia.command import UDSScanner
 from gallia.services.uds.core.constants import CDTCSSubFuncs, DSCSubFuncs, UDSErrorCodes
 from gallia.services.uds.core.service import NegativeResponse
-from gallia.utils import auto_int, g_repr
+from gallia.services.uds.core.utils import g_repr
+from gallia.utils import auto_int
 
 
 class DTCPrimitive(UDSScanner):

--- a/src/gallia/commands/primitive/uds/ecu_reset.py
+++ b/src/gallia/commands/primitive/uds/ecu_reset.py
@@ -6,8 +6,9 @@ import asyncio
 from argparse import Namespace
 
 from gallia.command import UDSScanner
-from gallia.services.uds.core.service import NegativeResponse, UDSResponse
-from gallia.utils import auto_int, g_repr
+from gallia.services.uds import NegativeResponse, UDSResponse
+from gallia.services.uds.core.utils import g_repr
+from gallia.utils import auto_int
 
 
 class ECUResetPrimitive(UDSScanner):
@@ -21,10 +22,17 @@ class ECUResetPrimitive(UDSScanner):
         self.parser.set_defaults(properties=False)
 
         self.parser.add_argument(
-            "--session", type=auto_int, default=0x01, help="set session perform test in"
+            "--session",
+            type=auto_int,
+            default=0x01,
+            help="set session perform test in",
         )
         self.parser.add_argument(
-            "-f", "--subfunc", type=auto_int, default=0x01, help="subfunc"
+            "-f",
+            "--subfunc",
+            type=auto_int,
+            default=0x01,
+            help="subfunc",
         )
 
     async def main(self, args: Namespace) -> None:

--- a/src/gallia/commands/primitive/uds/iocbi.py
+++ b/src/gallia/commands/primitive/uds/iocbi.py
@@ -7,8 +7,9 @@ import sys
 from argparse import Namespace
 
 from gallia.command import UDSScanner
-from gallia.services.uds.core.service import NegativeResponse
-from gallia.utils import auto_int, g_repr
+from gallia.services.uds import NegativeResponse
+from gallia.services.uds.core.utils import g_repr
+from gallia.utils import auto_int
 
 
 class IOCBIPrimitive(UDSScanner):
@@ -68,7 +69,7 @@ class IOCBIPrimitive(UDSScanner):
             await self.ecu.check_and_set_session(args.session)
         except Exception as e:
             self.logger.critical(
-                f"Could not change to session: {g_repr(args.session)}: {g_repr(e)}"
+                f"Could not change to session: {g_repr(args.session)}: {e!r}"
             )
             sys.exit(1)
 

--- a/src/gallia/commands/primitive/uds/read_by_identifier.py
+++ b/src/gallia/commands/primitive/uds/read_by_identifier.py
@@ -7,7 +7,7 @@ from argparse import Namespace
 
 from gallia.command import UDSScanner
 from gallia.services.uds.core.service import NegativeResponse
-from gallia.utils import auto_int, g_repr
+from gallia.utils import auto_int
 
 
 class ReadByIdentifierPrimitive(UDSScanner):
@@ -38,7 +38,7 @@ class ReadByIdentifierPrimitive(UDSScanner):
             if args.session != 0x01:
                 await self.ecu.set_session(args.session)
         except Exception as e:
-            self.logger.critical(f"fatal error: {g_repr(e)}")
+            self.logger.critical(f"fatal error: {e!r}")
             sys.exit(1)
 
         resp = await self.ecu.read_data_by_identifier(args.data_id)

--- a/src/gallia/commands/primitive/uds/read_error_log.py
+++ b/src/gallia/commands/primitive/uds/read_error_log.py
@@ -6,8 +6,9 @@ import asyncio
 from argparse import Namespace
 
 from gallia.command import UDSScanner
-from gallia.services.uds.core.service import NegativeResponse
-from gallia.utils import auto_int, g_repr
+from gallia.services.uds import NegativeResponse
+from gallia.services.uds.core.utils import g_repr
+from gallia.utils import auto_int
 
 
 class ReadErrorLogPrimitive(UDSScanner):

--- a/src/gallia/commands/primitive/uds/rmba.py
+++ b/src/gallia/commands/primitive/uds/rmba.py
@@ -6,8 +6,9 @@ import sys
 from argparse import Namespace
 
 from gallia.command import UDSScanner
-from gallia.services.uds.core.service import NegativeResponse
-from gallia.utils import auto_int, g_repr
+from gallia.services.uds import NegativeResponse
+from gallia.services.uds.core.utils import g_repr
+from gallia.utils import auto_int
 
 
 class RMBAPrimitive(UDSScanner):
@@ -42,7 +43,7 @@ class RMBAPrimitive(UDSScanner):
             await self.ecu.check_and_set_session(args.session)
         except Exception as e:
             self.logger.critical(
-                f"Could not change to session: {g_repr(args.session)}: {g_repr(e)}"
+                f"Could not change to session: {g_repr(args.session)}: {e!r}"
             )
             sys.exit(1)
 

--- a/src/gallia/commands/primitive/uds/rtcl.py
+++ b/src/gallia/commands/primitive/uds/rtcl.py
@@ -8,8 +8,10 @@ import sys
 from argparse import Namespace
 
 from gallia.command import UDSScanner
-from gallia.services.uds.core.service import NegativeResponse, RoutineControlResponse
-from gallia.utils import auto_int, g_repr
+from gallia.services.uds import NegativeResponse
+from gallia.services.uds.core.service import RoutineControlResponse
+from gallia.services.uds.core.utils import g_repr
+from gallia.utils import auto_int
 
 
 class RTCLPrimitive(UDSScanner):
@@ -90,7 +92,7 @@ class RTCLPrimitive(UDSScanner):
             await self.ecu.check_and_set_session(args.session)
         except Exception as e:
             self.logger.critical(
-                f"Could not change to session: {g_repr(args.session)}: {g_repr(e)}"
+                f"Could not change to session: {g_repr(args.session)}: {e!r}"
             )
             sys.exit(1)
 
@@ -109,7 +111,7 @@ class RTCLPrimitive(UDSScanner):
             else:
                 self.logger.result("[start] Positive response:")
                 self.logger.result(f"hex: {resp.routine_status_record.hex()}")
-                self.logger.result(f"raw: {repr(resp.routine_status_record)}")
+                self.logger.result(f"raw: {resp.routine_status_record!r}")
 
         if args.stop:
             delay = args.stop_delay
@@ -129,7 +131,7 @@ class RTCLPrimitive(UDSScanner):
             else:
                 self.logger.result("[stop] Positive response:")
                 self.logger.result(f"hex: {resp.routine_status_record.hex()}")
-                self.logger.result(f"raw: {repr(resp.routine_status_record)}")
+                self.logger.result(f"raw: {resp.routine_status_record!r}")
 
         if args.results:
             delay = args.results_delay
@@ -149,4 +151,4 @@ class RTCLPrimitive(UDSScanner):
             else:
                 self.logger.result("[get result] Positive response:")
                 self.logger.result(f"hex: {resp.routine_status_record.hex()}")
-                self.logger.result(f"raw: {repr(resp.routine_status_record)}")
+                self.logger.result(f"raw: {resp.routine_status_record!r}")

--- a/src/gallia/commands/primitive/uds/send_pdu.py
+++ b/src/gallia/commands/primitive/uds/send_pdu.py
@@ -7,17 +7,16 @@ import sys
 from argparse import Namespace
 
 from gallia.command import UDSScanner
-from gallia.services.uds.core.client import UDSRequestConfig
-from gallia.services.uds.core.exception import UDSException
-from gallia.services.uds.core.service import (
+from gallia.services.uds import (
     NegativeResponse,
-    RawRequest,
-    RawResponse,
     UDSRequest,
+    UDSRequestConfig,
     UDSResponse,
 )
+from gallia.services.uds.core.exception import UDSException
+from gallia.services.uds.core.service import RawRequest, RawResponse
 from gallia.services.uds.helpers import raise_for_error
-from gallia.utils import auto_int, g_repr
+from gallia.utils import auto_int
 
 
 class SendPDUPrimitive(UDSScanner):
@@ -68,7 +67,7 @@ class SendPDUPrimitive(UDSScanner):
                 config=UDSRequestConfig(max_retry=args.max_retry),
             )
         except UDSException as e:
-            self.logger.error(g_repr(e))
+            self.logger.error(repr(e))
             sys.exit(1)
 
         if isinstance(response, NegativeResponse):

--- a/src/gallia/commands/primitive/uds/wmba.py
+++ b/src/gallia/commands/primitive/uds/wmba.py
@@ -8,8 +8,9 @@ from argparse import Namespace
 from pathlib import Path
 
 from gallia.command import UDSScanner
-from gallia.services.uds.core.service import NegativeResponse
-from gallia.utils import auto_int, g_repr
+from gallia.services.uds import NegativeResponse
+from gallia.services.uds.core.utils import g_repr
+from gallia.utils import auto_int
 
 
 class WMBAPrimitive(UDSScanner):
@@ -33,7 +34,9 @@ class WMBAPrimitive(UDSScanner):
         )
         data_group = self.parser.add_mutually_exclusive_group(required=True)
         data_group.add_argument(
-            "--data", type=binascii.unhexlify, help="The data which should be written"
+            "--data",
+            type=binascii.unhexlify,
+            help="The data which should be written",
         )
         data_group.add_argument(
             "--data-file",
@@ -46,7 +49,7 @@ class WMBAPrimitive(UDSScanner):
             await self.ecu.check_and_set_session(args.session)
         except Exception as e:
             self.logger.critical(
-                f"Could not change to session: {g_repr(args.session)}: {g_repr(e)}"
+                f"Could not change to session: {g_repr(args.session)}: {e!r}"
             )
             sys.exit(1)
 

--- a/src/gallia/commands/primitive/uds/write_by_identifier.py
+++ b/src/gallia/commands/primitive/uds/write_by_identifier.py
@@ -7,8 +7,8 @@ import sys
 from argparse import Namespace
 
 from gallia.command import UDSScanner
-from gallia.services.uds.core.service import NegativeResponse, UDSResponse
-from gallia.utils import auto_int, g_repr
+from gallia.services.uds import NegativeResponse, UDSResponse
+from gallia.utils import auto_int
 
 
 class WriteByIdentifierPrimitive(UDSScanner):
@@ -48,7 +48,7 @@ class WriteByIdentifierPrimitive(UDSScanner):
                     self.logger.critical(f"could not change to session: {resp}")
                     sys.exit(1)
         except Exception as e:
-            self.logger.critical(f"fatal error: {g_repr(e)}")
+            self.logger.critical(f"fatal error: {e!r}")
             sys.exit(1)
 
         resp = await self.ecu.write_data_by_identifier(args.data_id, args.data)

--- a/src/gallia/commands/scan/uds/identifiers.py
+++ b/src/gallia/commands/scan/uds/identifiers.py
@@ -13,9 +13,9 @@ from gallia.services.uds.core.client import UDSRequestConfig
 from gallia.services.uds.core.constants import RCSubFuncs, UDSErrorCodes, UDSIsoServices
 from gallia.services.uds.core.exception import IllegalResponse
 from gallia.services.uds.core.service import NegativeResponse, UDSResponse
-from gallia.services.uds.core.utils import service_repr
+from gallia.services.uds.core.utils import g_repr, service_repr
 from gallia.services.uds.helpers import suggests_service_not_supported
-from gallia.utils import ParseSkips, auto_int, g_repr
+from gallia.utils import ParseSkips, auto_int
 
 
 class ScanIdentifiers(UDSScanner):

--- a/src/gallia/commands/scan/uds/memory.py
+++ b/src/gallia/commands/scan/uds/memory.py
@@ -8,11 +8,9 @@ from argparse import Namespace
 from binascii import unhexlify
 
 from gallia.command import UDSScanner
-from gallia.services.uds.core.client import UDSRequestConfig
-from gallia.services.uds.core.constants import UDSErrorCodes
-from gallia.services.uds.core.service import NegativeResponse
-from gallia.services.uds.core.utils import uds_memory_parameters
-from gallia.utils import auto_int, g_repr
+from gallia.services.uds import NegativeResponse, UDSErrorCodes, UDSRequestConfig
+from gallia.services.uds.core.utils import g_repr, uds_memory_parameters
+from gallia.utils import auto_int
 
 
 class MemoryFunctionsScanner(UDSScanner):

--- a/src/gallia/commands/scan/uds/reset.py
+++ b/src/gallia/commands/scan/uds/reset.py
@@ -9,14 +9,14 @@ from argparse import Namespace
 from typing import Any
 
 from gallia.command import UDSScanner
-from gallia.services.uds.core.client import UDSRequestConfig
+from gallia.services.uds import NegativeResponse, UDSRequestConfig, UDSResponse
 from gallia.services.uds.core.exception import (
     IllegalResponse,
     UnexpectedNegativeResponse,
 )
-from gallia.services.uds.core.service import NegativeResponse, UDSResponse
+from gallia.services.uds.core.utils import g_repr
 from gallia.services.uds.helpers import suggests_sub_function_not_supported
-from gallia.utils import ParseSkips, auto_int, g_repr
+from gallia.utils import ParseSkips, auto_int
 
 
 class ResetScanner(UDSScanner):

--- a/src/gallia/commands/scan/uds/sa_dump_seeds.py
+++ b/src/gallia/commands/scan/uds/sa_dump_seeds.py
@@ -14,9 +14,9 @@ import aiofiles
 
 from gallia.command import UDSScanner
 from gallia.config import Config
-from gallia.services.uds.core.client import UDSRequestConfig
-from gallia.services.uds.core.service import NegativeResponse
-from gallia.utils import auto_int, g_repr
+from gallia.services.uds import NegativeResponse, UDSRequestConfig
+from gallia.services.uds.core.utils import g_repr
+from gallia.utils import auto_int
 
 
 class SASeedsDumper(UDSScanner):

--- a/src/gallia/commands/scan/uds/services.py
+++ b/src/gallia/commands/scan/uds/services.py
@@ -9,12 +9,16 @@ from binascii import unhexlify
 from typing import Any
 
 from gallia.command import UDSScanner
-from gallia.services.uds.core.client import UDSRequestConfig
-from gallia.services.uds.core.constants import UDSIsoServices
+from gallia.services.uds import (
+    NegativeResponse,
+    UDSIsoServices,
+    UDSRequestConfig,
+    UDSResponse,
+)
 from gallia.services.uds.core.exception import UDSException
-from gallia.services.uds.core.service import NegativeResponse, UDSResponse
+from gallia.services.uds.core.utils import g_repr
 from gallia.services.uds.helpers import suggests_service_not_supported
-from gallia.utils import ParseSkips, auto_int, g_repr
+from gallia.utils import ParseSkips, auto_int
 
 
 class ServicesScanner(UDSScanner):
@@ -148,7 +152,7 @@ class ServicesScanner(UDSScanner):
                     self.logger.info(f"{g_repr(sid)}: timeout")
                     continue
                 except Exception as e:
-                    self.logger.info(f"{g_repr(sid)}: {g_repr(e)} occurred")
+                    self.logger.info(f"{g_repr(sid)}: {e!r} occurred")
                     await self.ecu.reconnect()
                     continue
 

--- a/src/gallia/commands/scan/uds/sessions.py
+++ b/src/gallia/commands/scan/uds/sessions.py
@@ -8,14 +8,15 @@ from argparse import Namespace
 from typing import Any
 
 from gallia.command import UDSScanner
-from gallia.services.uds.core.client import UDSRequestConfig
-from gallia.services.uds.core.constants import UDSErrorCodes
-from gallia.services.uds.core.service import (
-    DiagnosticSessionControlResponse,
+from gallia.services.uds import (
     NegativeResponse,
+    UDSErrorCodes,
+    UDSRequestConfig,
     UDSResponse,
 )
-from gallia.utils import auto_int, g_repr
+from gallia.services.uds.core.service import DiagnosticSessionControlResponse
+from gallia.services.uds.core.utils import g_repr
+from gallia.utils import auto_int
 
 
 class SessionsScanner(UDSScanner):
@@ -174,9 +175,7 @@ class SessionsScanner(UDSScanner):
                             )
                             sys.exit(1)
                     except Exception as e:
-                        self.logger.error(
-                            f"Could not change to default session: {g_repr(e)}"
-                        )
+                        self.logger.error(f"Could not change to default session: {e!r}")
                         sys.exit(1)
 
                     self.logger.debug(

--- a/src/gallia/db/handler.py
+++ b/src/gallia/db/handler.py
@@ -20,7 +20,7 @@ from gallia.services.uds.core.service import (
     UDSResponse,
 )
 from gallia.services.uds.core.utils import bytes_repr as bytes_repr_
-from gallia.utils import g_repr
+from gallia.services.uds.core.utils import g_repr
 
 
 def bytes_repr(data: bytes) -> str:

--- a/src/gallia/dumpcap.py
+++ b/src/gallia/dumpcap.py
@@ -19,7 +19,7 @@ from urllib.parse import urlparse
 
 from gallia.log import Logger, get_logger
 from gallia.transports import ISOTPTransport, RawCANTransport, TargetURI
-from gallia.utils import auto_int, g_repr, split_host_port
+from gallia.utils import auto_int, split_host_port
 
 
 class Dumpcap:
@@ -76,7 +76,7 @@ class Dumpcap:
             )
             await asyncio.sleep(0.2)
         except Exception as e:
-            logger.error(f"Could not start dumpcap: ({g_repr(e)})")
+            logger.error(f"Could not start dumpcap: ({e!r})")
             raise
 
         if proc.returncode:

--- a/src/gallia/services/uds/__init__.py
+++ b/src/gallia/services/uds/__init__.py
@@ -3,7 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from gallia.services.uds.core.client import UDSClient
+from gallia.services.uds.core.client import UDSClient, UDSRequestConfig
+from gallia.services.uds.core.constants import UDSErrorCodes, UDSIsoServices
 from gallia.services.uds.core.service import (
     NegativeResponse,
     PositiveResponse,
@@ -15,12 +16,15 @@ from gallia.services.uds.core.service import (
 from gallia.services.uds.ecu import ECU
 
 __all__ = [
-    "UDSRequest",
-    "UDSResponse",
+    "ECU",
+    "NegativeResponse",
+    "PositiveResponse",
     "SubFunctionRequest",
     "SubFunctionResponse",
-    "PositiveResponse",
-    "NegativeResponse",
     "UDSClient",
-    "ECU",
+    "UDSErrorCodes",
+    "UDSIsoServices",
+    "UDSRequest",
+    "UDSRequestConfig",
+    "UDSResponse",
 ]

--- a/src/gallia/services/uds/core/utils.py
+++ b/src/gallia/services/uds/core/utils.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from binascii import hexlify
+from enum import Enum
 from math import ceil
 from typing import Any
 
@@ -71,6 +72,31 @@ def any_repr(x: Any) -> str:
         return f'[{", ".join(any_repr(y) for y in x)}]'
 
     return str(x)
+
+
+def g_repr(x: Any) -> str:
+    """
+    Object string representation with default gallia output settings.
+    """
+    if isinstance(x, Enum):
+        return str(x.name)
+    if isinstance(x, bool):
+        return repr(x)
+    if isinstance(x, int):
+        return int_repr(x)
+    if isinstance(x, str):
+        return x
+    if isinstance(x, (bytes, bytearray)):
+        return bytes_repr(x)
+    if isinstance(x, list):
+        return f'[{", ".join(g_repr(y) for y in x)}]'
+    if isinstance(x, dict):
+        return f'{{{", ".join(f"{g_repr(k)}: {g_repr(v)}" for k, v in x.items())}}}'
+    # XXX: Avoid the import which causes cyclic imports.
+    # TODO: Find out how to replace this helper.
+    if type(x).__name__ == "NegativeResponse":
+        return str(x)
+    return repr(x)
 
 
 def bytes_repr(b: bytes, prefix: bool = False, max_length: int | None = 20) -> str:

--- a/src/gallia/services/uds/ecu.py
+++ b/src/gallia/services/uds/ecu.py
@@ -20,14 +20,13 @@ from gallia.services.uds.core.exception import (
     UDSException,
     UnexpectedNegativeResponse,
 )
-from gallia.services.uds.core.utils import from_bytes
+from gallia.services.uds.core.utils import from_bytes, g_repr
 from gallia.services.uds.helpers import (
     as_exception,
     raise_for_error,
     suggests_identifier_not_supported,
 )
 from gallia.transports.base import BaseTransport
-from gallia.utils import g_repr
 
 if TYPE_CHECKING:
     from gallia.db.handler import DBHandler

--- a/src/gallia/utils.py
+++ b/src/gallia/utils.py
@@ -11,16 +11,12 @@ import re
 import sys
 from argparse import Action, ArgumentError, ArgumentParser, Namespace
 from collections.abc import Awaitable, Callable, Sequence
-from enum import Enum
 from pathlib import Path
 from types import ModuleType
 from typing import TYPE_CHECKING, Any, TypeVar
 from urllib.parse import urlparse
 
 import aiofiles
-
-from gallia.services.uds.core.service import NegativeResponse
-from gallia.services.uds.core.utils import bytes_repr, int_repr
 
 if TYPE_CHECKING:
     from gallia.db.handler import DBHandler
@@ -99,29 +95,6 @@ def can_id_repr(i: int) -> str:
     Default string representation of a CAN id.
     """
     return f"{i:03x}"
-
-
-def g_repr(x: Any) -> str:
-    """
-    Object string representation with default gallia output settings.
-    """
-    if isinstance(x, Enum):
-        return str(x.name)
-    if isinstance(x, bool):
-        return repr(x)
-    if isinstance(x, int):
-        return int_repr(x)
-    if isinstance(x, str):
-        return x
-    if isinstance(x, (bytes, bytearray)):
-        return bytes_repr(x)
-    if isinstance(x, list):
-        return f'[{", ".join(g_repr(y) for y in x)}]'
-    if isinstance(x, dict):
-        return f'{{{", ".join(f"{g_repr(k)}: {g_repr(v)}" for k, v in x.items())}}}'
-    if isinstance(x, NegativeResponse):
-        return str(x)
-    return repr(x)
 
 
 def _unravel(listing: str) -> list[int]:

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -7,3 +7,5 @@ import subprocess
 
 def test_help() -> None:
     subprocess.run(["gallia", "-h"], stdout=subprocess.DEVNULL, check=True)
+    subprocess.run(["netzteil", "-h"], stdout=subprocess.DEVNULL, check=True)
+    subprocess.run(["hr", "-h"], stdout=subprocess.DEVNULL, check=True)


### PR DESCRIPTION
- chore: Remove unused dep in flake.nix
- fix: Remove circular import by moving g_repr into uds.core
