### PR TITLE
feat(scan-reset): added option to power-cycle on timeout

### DIFF
--- a/src/gallia/commands/scan/uds/reset.py
+++ b/src/gallia/commands/scan/uds/reset.py
@@ -160,8 +160,10 @@ class ResetScanner(UDSScanner):
                             )
                             sys.exit(1)
                         except ConnectionError:
-                            msg = f"{g_repr(sub_func)}: lost connection to ECU (post), current session: " \
-                                  f"{g_repr(session)}"
+                            msg = (
+                                f"{g_repr(sub_func)}: lost connection to ECU (post), current session: "
+                                f"{g_repr(session)}"
+                            )
                             self.logger.warning(msg)
                             await self.ecu.reconnect()
                             continue


### PR DESCRIPTION
ECUReset can trigger shutdowns of ECUs which currently leads to TimeoutError, which in turns leads to termination of the scanner.
This commit, introduces the cli option `--power-cycle-on-timeout`. In case this option is set, the ECU power-cycles the ECU after such a timeout and tries to reconnect to the ECU afterwards.
Tested with isotp and connection-oriented protocols.

Co-authored by @VeroSec and @emedav 