### PR TITLE
fix: Do not fail when different owner of lockfile

### DIFF
--- a/src/gallia/command/base.py
+++ b/src/gallia/command/base.py
@@ -317,11 +317,7 @@ class BaseCommand(ABC):
         raise ValueError("base_dir or force_path must be different from None")
 
     def _aquire_flock(self, path: Path) -> None:
-        try:
-            # Raises 'PermissionError' when file was created by another user.
-            path.touch()
-        except PermissionError:
-            pass
+        path.touch()
         self._lock_file_fd = os.open(path, os.O_RDONLY)
         try:
             # First do a non blocking flock. If waiting is required,

--- a/src/gallia/command/base.py
+++ b/src/gallia/command/base.py
@@ -317,7 +317,8 @@ class BaseCommand(ABC):
         raise ValueError("base_dir or force_path must be different from None")
 
     def _aquire_flock(self, path: Path) -> None:
-        path.touch()
+        if not path.exists():
+            path.touch()
         self._lock_file_fd = os.open(path, os.O_RDONLY)
         try:
             # First do a non blocking flock. If waiting is required,


### PR DESCRIPTION
- Revert "fix: handle PermissionError for lock files created by other users (#326)"
- fix: Do not fail when different owner of lockfile

When the owner of the lockfile is different from the current user, `.touch()` fails. The lock can be created anyway. Only execute `.touch()` when the file does not exist.