### PR TITLE
fix: Fix nameclash in XDG lib by vendoring

### DIFF
--- a/LICENSES/ISC.txt
+++ b/LICENSES/ISC.txt
@@ -1,0 +1,8 @@
+ISC License:
+
+Copyright (c) 2004-2010 by Internet Systems Consortium, Inc. ("ISC")
+Copyright (c) 1995-2003 by Internet Software Consortium
+
+Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND ISC DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL ISC BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.

--- a/poetry.lock
+++ b/poetry.lock
@@ -1199,14 +1199,6 @@ optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 
 [[package]]
-name = "xdg"
-version = "5.1.1"
-description = "Variables defined by the XDG Base Directory Specification"
-category = "main"
-optional = false
-python-versions = ">=3.6,<4.0"
-
-[[package]]
 name = "yarl"
 version = "1.8.2"
 description = "Yet another URL library"
@@ -1235,7 +1227,7 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.10,<3.12"
-content-hash = "d7bb3766646a0dbe8d0ef77c51a486feda7372a5922146705069a54021f95fa3"
+content-hash = "73247e0983f241c30ab302d538b25ecbdb98d25085db92c2ae90e08d5389b237"
 
 [metadata.files]
 aiofiles = [
@@ -1372,23 +1364,14 @@ binaryornot = [
     {file = "binaryornot-0.4.4.tar.gz", hash = "sha256:359501dfc9d40632edc9fac890e19542db1a287bbcfa58175b66658392018061"},
 ]
 black = [
-    {file = "black-22.10.0-1fixedarch-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:5cc42ca67989e9c3cf859e84c2bf014f6633db63d1cbdf8fdb666dcd9e77e3fa"},
-    {file = "black-22.10.0-1fixedarch-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:5d8f74030e67087b219b032aa33a919fae8806d49c867846bfacde57f43972ef"},
-    {file = "black-22.10.0-1fixedarch-cp37-cp37m-macosx_10_16_x86_64.whl", hash = "sha256:197df8509263b0b8614e1df1756b1dd41be6738eed2ba9e9769f3880c2b9d7b6"},
-    {file = "black-22.10.0-1fixedarch-cp38-cp38-macosx_10_16_x86_64.whl", hash = "sha256:2644b5d63633702bc2c5f3754b1b475378fbbfb481f62319388235d0cd104c2d"},
-    {file = "black-22.10.0-1fixedarch-cp39-cp39-macosx_11_0_x86_64.whl", hash = "sha256:e41a86c6c650bcecc6633ee3180d80a025db041a8e2398dcc059b3afa8382cd4"},
-    {file = "black-22.10.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2039230db3c6c639bd84efe3292ec7b06e9214a2992cd9beb293d639c6402edb"},
     {file = "black-22.10.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:14ff67aec0a47c424bc99b71005202045dc09270da44a27848d534600ac64fc7"},
     {file = "black-22.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:819dc789f4498ecc91438a7de64427c73b45035e2e3680c92e18795a839ebb66"},
-    {file = "black-22.10.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5b9b29da4f564ba8787c119f37d174f2b69cdfdf9015b7d8c5c16121ddc054ae"},
     {file = "black-22.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b8b49776299fece66bffaafe357d929ca9451450f5466e997a7285ab0fe28e3b"},
     {file = "black-22.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:21199526696b8f09c3997e2b4db8d0b108d801a348414264d2eb8eb2532e540d"},
     {file = "black-22.10.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1e464456d24e23d11fced2bc8c47ef66d471f845c7b7a42f3bd77bf3d1789650"},
     {file = "black-22.10.0-cp37-cp37m-win_amd64.whl", hash = "sha256:9311e99228ae10023300ecac05be5a296f60d2fd10fff31cf5c1fa4ca4b1988d"},
-    {file = "black-22.10.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:fba8a281e570adafb79f7755ac8721b6cf1bbf691186a287e990c7929c7692ff"},
     {file = "black-22.10.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:915ace4ff03fdfff953962fa672d44be269deb2eaf88499a0f8805221bc68c87"},
     {file = "black-22.10.0-cp38-cp38-win_amd64.whl", hash = "sha256:444ebfb4e441254e87bad00c661fe32df9969b2bf224373a448d8aca2132b395"},
-    {file = "black-22.10.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:974308c58d057a651d182208a484ce80a26dac0caef2895836a92dd6ebd725e0"},
     {file = "black-22.10.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:72ef3925f30e12a184889aac03d77d031056860ccae8a1e519f6cbb742736383"},
     {file = "black-22.10.0-cp39-cp39-win_amd64.whl", hash = "sha256:432247333090c8c5366e69627ccb363bc58514ae3e63f7fc75c54b1ea80fa7de"},
     {file = "black-22.10.0-py3-none-any.whl", hash = "sha256:c957b2b4ea88587b46cf49d1dc17681c1e672864fd7af32fc1e9664d572b3458"},
@@ -2381,10 +2364,6 @@ wrapt = [
     {file = "wrapt-1.14.1-cp39-cp39-win32.whl", hash = "sha256:dee0ce50c6a2dd9056c20db781e9c1cfd33e77d2d569f5d1d9321c641bb903d5"},
     {file = "wrapt-1.14.1-cp39-cp39-win_amd64.whl", hash = "sha256:dee60e1de1898bde3b238f18340eec6148986da0455d8ba7848d50470a7a32fb"},
     {file = "wrapt-1.14.1.tar.gz", hash = "sha256:380a85cf89e0e69b7cfbe2ea9f765f004ff419f34194018a6827ac0e3edfed4d"},
-]
-xdg = [
-    {file = "xdg-5.1.1-py3-none-any.whl", hash = "sha256:865a7b56ed1d4cd2fce2ead1eddf97360843619757f473cd90b75f1817ca541d"},
-    {file = "xdg-5.1.1.tar.gz", hash = "sha256:aa619f26ccec6088b2a6018721d4ee86e602099b24644a90a8d3308a25acd06c"},
 ]
 yarl = [
     {file = "yarl-1.8.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:bb81f753c815f6b8e2ddd2eef3c855cf7da193b82396ac013c661aaa6cc6b0a5"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ zstandard = ">=0.17,<0.20"
 python-can = "^4.0"
 tabulate = ">=0.8.9,<0.10.0"
 construct = "^2.10.67"
-xdg = "^5.1"
 tomli = { version = "^2.0.1", python = "<3.11" }
 msgspec = ">=0.8,<0.11"
 pydantic = "^1.10"

--- a/src/gallia/config.py
+++ b/src/gallia/config.py
@@ -8,7 +8,8 @@ from pathlib import Path
 from typing import Any
 
 from pygit2 import discover_repository
-from xdg import xdg_config_dirs
+
+from gallia.xdg import xdg_config_dirs
 
 # TODO: Remove this check when dropping Python 3.10.
 if sys.version_info[1] < 11:

--- a/src/gallia/xdg.py
+++ b/src/gallia/xdg.py
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: 2016-2021 Scott Stevenson <scott@stevenson.io>
+#
+# SPDX-License-Identifier: ISC
+
+"""XDG Base Directory Specification variables.
+xdg_cache_home(), xdg_config_home(), xdg_data_home(), and xdg_state_home()
+return pathlib.Path objects containing the value of the environment variable
+named XDG_CACHE_HOME, XDG_CONFIG_HOME, XDG_DATA_HOME, and XDG_STATE_HOME
+respectively, or the default defined in the specification if the environment
+variable is unset, empty, or contains a relative path rather than absolute
+path.
+xdg_config_dirs() and xdg_data_dirs() return a list of pathlib.Path
+objects containing the value, split on colons, of the environment
+variable named XDG_CONFIG_DIRS and XDG_DATA_DIRS respectively, or the
+default defined in the specification if the environment variable is
+unset or empty. Relative paths are ignored, as per the specification.
+xdg_runtime_dir() returns a pathlib.Path object containing the value of
+the XDG_RUNTIME_DIR environment variable, or None if the environment
+variable is not set, or contains a relative path rather than absolute path.
+"""
+
+import os
+from pathlib import Path
+from typing import TypeVar
+
+T = TypeVar("T", Path, None)
+
+
+def _path_from_env(variable: str, default: T) -> Path | T:
+    """Read an environment variable as a path.
+    The environment variable with the specified name is read, and its
+    value returned as a path. If the environment variable is not set, is
+    set to the empty string, or is set to a relative rather than
+    absolute path, the default value is returned.
+    Parameters
+    ----------
+    variable : str
+        Name of the environment variable.
+    default : Path
+        Default value.
+    Returns
+    -------
+    Path
+        Value from environment or default.
+    """
+    value = os.environ.get(variable)
+    if value and os.path.isabs(value):
+        return Path(value)
+    return default
+
+
+def _paths_from_env(variable: str, default: list[Path]) -> list[Path]:
+    """Read an environment variable as a list of paths.
+    The environment variable with the specified name is read, and its
+    value split on colons and returned as a list of paths. If the
+    environment variable is not set, or set to the empty string, the
+    default value is returned. Relative paths are ignored, as per the
+    specification.
+    Parameters
+    ----------
+    variable : str
+        Name of the environment variable.
+    default : List[Path]
+        Default value.
+    Returns
+    -------
+    List[Path]
+        Value from environment or default.
+    """
+    value = os.environ.get(variable)
+    if value:
+        paths = [Path(path) for path in value.split(":") if os.path.isabs(path)]
+        if paths:
+            return paths
+    return default
+
+
+def xdg_cache_home() -> Path:
+    """Return a Path corresponding to XDG_CACHE_HOME."""
+    return _path_from_env("XDG_CACHE_HOME", Path.home() / ".cache")
+
+
+def xdg_config_dirs() -> list[Path]:
+    """Return a list of Paths corresponding to XDG_CONFIG_DIRS."""
+    return _paths_from_env("XDG_CONFIG_DIRS", [Path("/etc/xdg")])
+
+
+def xdg_config_home() -> Path:
+    """Return a Path corresponding to XDG_CONFIG_HOME."""
+    return _path_from_env("XDG_CONFIG_HOME", Path.home() / ".config")
+
+
+def xdg_data_dirs() -> list[Path]:
+    """Return a list of Paths corresponding to XDG_DATA_DIRS."""
+    return _paths_from_env(
+        "XDG_DATA_DIRS",
+        [Path(path) for path in "/usr/local/share/:/usr/share/".split(":")],
+    )
+
+
+def xdg_data_home() -> Path:
+    """Return a Path corresponding to XDG_DATA_HOME."""
+    return _path_from_env("XDG_DATA_HOME", Path.home() / ".local" / "share")
+
+
+def xdg_runtime_dir() -> Path | None:
+    """Return a Path corresponding to XDG_RUNTIME_DIR.
+    If the XDG_RUNTIME_DIR environment variable is not set, None will be
+    returned as per the specification.
+    """
+    return _path_from_env("XDG_RUNTIME_DIR", None)
+
+
+def xdg_state_home() -> Path:
+    """Return a Path corresponding to XDG_STATE_HOME."""
+    return _path_from_env("XDG_STATE_HOME", Path.home() / ".local" / "state")

--- a/tests/test_xdg.py
+++ b/tests/test_xdg.py
@@ -1,0 +1,201 @@
+# SPDX-FileCopyrightText: 2016-2021 Scott Stevenson <scott@stevenson.io>
+#
+# SPDX-License-Identifier: ISC
+
+import os
+from pathlib import Path
+
+from _pytest.monkeypatch import MonkeyPatch
+
+from gallia import xdg
+
+HOME_DIR = Path("/homedir")
+
+
+def test_xdg_cache_home_unset(monkeypatch: MonkeyPatch) -> None:
+    """Test xdg_cache_home when XDG_CACHE_HOME is unset."""
+    monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+    monkeypatch.setenv("HOME", os.fspath(HOME_DIR))
+    assert xdg.xdg_cache_home() == HOME_DIR / ".cache"
+
+
+def test_xdg_cache_home_empty(monkeypatch: MonkeyPatch) -> None:
+    """Test xdg_cache_home when XDG_CACHE_HOME is empty."""
+    monkeypatch.setenv("HOME", os.fspath(HOME_DIR))
+    monkeypatch.setenv("XDG_CACHE_HOME", "")
+    assert xdg.xdg_cache_home() == HOME_DIR / ".cache"
+
+
+def test_xdg_cache_home_relative(monkeypatch: MonkeyPatch) -> None:
+    """Test xdg_cache_home when XDG_CACHE_HOME is relative path."""
+    monkeypatch.setenv("HOME", os.fspath(HOME_DIR))
+    monkeypatch.setenv("XDG_CACHE_HOME", "rela/tive")
+    assert xdg.xdg_cache_home() == HOME_DIR / ".cache"
+
+
+def test_xdg_cache_home_absolute(monkeypatch: MonkeyPatch) -> None:
+    """Test xdg_cache_home when XDG_CACHE_HOME is absolute path."""
+    monkeypatch.setenv("XDG_CACHE_HOME", "/xdg_cache_home")
+    assert xdg.xdg_cache_home() == Path("/xdg_cache_home")
+
+
+def test_xdg_config_dirs_unset(monkeypatch: MonkeyPatch) -> None:
+    """Test xdg_config_dirs when XDG_CONFIG_DIRS is unset."""
+    monkeypatch.delenv("XDG_CONFIG_DIRS", raising=False)
+    assert xdg.xdg_config_dirs() == [Path("/etc/xdg")]
+
+
+def test_xdg_config_dirs_empty(monkeypatch: MonkeyPatch) -> None:
+    """Test xdg_config_dirs when XDG_CONFIG_DIRS is empty."""
+    monkeypatch.setenv("XDG_CONFIG_DIRS", "")
+    assert xdg.xdg_config_dirs() == [Path("/etc/xdg")]
+
+
+def test_xdg_config_dirs_relative(monkeypatch: MonkeyPatch) -> None:
+    """Test xdg_config_dirs when XDG_CONFIG_DIRS is relative paths."""
+    monkeypatch.setenv("XDG_CONFIG_DIRS", "rela/tive:ano/ther")
+    assert xdg.xdg_config_dirs() == [Path("/etc/xdg")]
+
+
+def test_xdg_config_dirs_set(monkeypatch: MonkeyPatch) -> None:
+    """Test xdg_config_dirs when XDG_CONFIG_DIRS is set."""
+    monkeypatch.setenv("XDG_CONFIG_DIRS", "/first:rela/tive:/sec/ond")
+    assert xdg.xdg_config_dirs() == [Path("/first"), Path("/sec/ond")]
+
+
+def test_xdg_config_home_unset(monkeypatch: MonkeyPatch) -> None:
+    """Test xdg_config_home when XDG_CONFIG_HOME is unset."""
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    monkeypatch.setenv("HOME", os.fspath(HOME_DIR))
+    assert xdg.xdg_config_home() == HOME_DIR / ".config"
+
+
+def test_xdg_config_home_empty(monkeypatch: MonkeyPatch) -> None:
+    """Test xdg_config_home when XDG_CONFIG_HOME is empty."""
+    monkeypatch.setenv("HOME", os.fspath(HOME_DIR))
+    monkeypatch.setenv("XDG_CONFIG_HOME", "")
+    assert xdg.xdg_config_home() == HOME_DIR / ".config"
+
+
+def test_xdg_config_home_relative(monkeypatch: MonkeyPatch) -> None:
+    """Test xdg_config_home when XDG_CONFIG_HOME is relative path."""
+    monkeypatch.setenv("HOME", os.fspath(HOME_DIR))
+    monkeypatch.setenv("XDG_CONFIG_HOME", "rela/tive")
+    assert xdg.xdg_config_home() == HOME_DIR / ".config"
+
+
+def test_xdg_config_home_absolute(monkeypatch: MonkeyPatch) -> None:
+    """Test xdg_config_home when XDG_CONFIG_HOME is absolute path."""
+    monkeypatch.setenv("XDG_CONFIG_HOME", "/xdg_config_home")
+    assert xdg.xdg_config_home() == Path("/xdg_config_home")
+
+
+def test_xdg_data_dirs_unset(monkeypatch: MonkeyPatch) -> None:
+    """Test xdg_data_dirs when XDG_DATA_DIRS is unset."""
+    monkeypatch.delenv("XDG_DATA_DIRS", raising=False)
+    assert xdg.xdg_data_dirs() == [
+        Path("/usr/local/share/"),
+        Path("/usr/share/"),
+    ]
+
+
+def test_xdg_data_dirs_empty(monkeypatch: MonkeyPatch) -> None:
+    """Test xdg_data_dirs when XDG_DATA_DIRS is empty."""
+    monkeypatch.setenv("XDG_DATA_DIRS", "")
+    assert xdg.xdg_data_dirs() == [
+        Path("/usr/local/share/"),
+        Path("/usr/share/"),
+    ]
+
+
+def test_xdg_data_dirs_relative(monkeypatch: MonkeyPatch) -> None:
+    """Test xdg_data_dirs when XDG_DATA_DIRS is relative paths."""
+    monkeypatch.setenv("XDG_DATA_DIRS", "rela/tive:ano/ther")
+    assert xdg.xdg_data_dirs() == [
+        Path("/usr/local/share/"),
+        Path("/usr/share/"),
+    ]
+
+
+def test_xdg_data_dirs_set(monkeypatch: MonkeyPatch) -> None:
+    """Test xdg_data_dirs when XDG_DATA_DIRS is set."""
+    monkeypatch.setenv("XDG_DATA_DIRS", "/first/:rela/tive:/sec/ond/")
+    assert xdg.xdg_data_dirs() == [Path("/first/"), Path("/sec/ond/")]
+
+
+def test_xdg_data_home_unset(monkeypatch: MonkeyPatch) -> None:
+    """Test xdg_data_home when XDG_DATA_HOME is unset."""
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+    monkeypatch.setenv("HOME", os.fspath(HOME_DIR))
+    assert xdg.xdg_data_home() == HOME_DIR / ".local" / "share"
+
+
+def test_xdg_data_home_empty(monkeypatch: MonkeyPatch) -> None:
+    """Test xdg_data_home when XDG_DATA_HOME is empty."""
+    monkeypatch.setenv("HOME", os.fspath(HOME_DIR))
+    monkeypatch.setenv("XDG_DATA_HOME", "")
+    assert xdg.xdg_data_home() == HOME_DIR / ".local" / "share"
+
+
+def test_xdg_data_home_relative(monkeypatch: MonkeyPatch) -> None:
+    """Test xdg_data_home when XDG_DATA_HOME is relative path."""
+    monkeypatch.setenv("HOME", os.fspath(HOME_DIR))
+    monkeypatch.setenv("XDG_DATA_HOME", "rela/tive")
+    assert xdg.xdg_data_home() == HOME_DIR / ".local" / "share"
+
+
+def test_xdg_data_home_absolute(monkeypatch: MonkeyPatch) -> None:
+    """Test xdg_data_home when XDG_DATA_HOME is absolute path."""
+    monkeypatch.setenv("XDG_DATA_HOME", "/xdg_data_home")
+    assert xdg.xdg_data_home() == Path("/xdg_data_home")
+
+
+def test_xdg_runtime_dir_unset(monkeypatch: MonkeyPatch) -> None:
+    """Test xdg_runtime_dir when XDG_RUNTIME_DIR is unset."""
+    monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+    assert xdg.xdg_runtime_dir() is None
+
+
+def test_xdg_runtime_dir_empty(monkeypatch: MonkeyPatch) -> None:
+    """Test xdg_runtime_dir when XDG_RUNTIME_DIR is empty."""
+    monkeypatch.setenv("XDG_RUNTIME_DIR", "")
+    assert xdg.xdg_runtime_dir() is None
+
+
+def test_xdg_runtime_dir_relative(monkeypatch: MonkeyPatch) -> None:
+    """Test xdg_runtime_dir when XDG_RUNTIME_DIR is relative path."""
+    monkeypatch.setenv("XDG_RUNTIME_DIR", "rela/tive")
+    assert xdg.xdg_runtime_dir() is None
+
+
+def test_xdg_runtime_dir_absolute(monkeypatch: MonkeyPatch) -> None:
+    """Test xdg_runtime_dir when XDG_RUNTIME_DIR is absolute path."""
+    monkeypatch.setenv("XDG_RUNTIME_DIR", "/xdg_runtime_dir")
+    assert xdg.xdg_runtime_dir() == Path("/xdg_runtime_dir")
+
+
+def test_xdg_state_home_unset(monkeypatch: MonkeyPatch) -> None:
+    """Test xdg_state_home when XDG_STATE_HOME is unset."""
+    monkeypatch.delenv("XDG_STATE_HOME", raising=False)
+    monkeypatch.setenv("HOME", os.fspath(HOME_DIR))
+    assert xdg.xdg_state_home() == HOME_DIR / ".local" / "state"
+
+
+def test_xdg_state_home_empty(monkeypatch: MonkeyPatch) -> None:
+    """Test xdg_state_home when XDG_STATE_HOME is empty."""
+    monkeypatch.setenv("HOME", os.fspath(HOME_DIR))
+    monkeypatch.setenv("XDG_STATE_HOME", "")
+    assert xdg.xdg_state_home() == HOME_DIR / ".local" / "state"
+
+
+def test_xdg_state_home_relative(monkeypatch: MonkeyPatch) -> None:
+    """Test xdg_state_home when XDG_STATE_HOME is relative path."""
+    monkeypatch.setenv("HOME", os.fspath(HOME_DIR))
+    monkeypatch.setenv("XDG_STATE_HOME", "rela/tive")
+    assert xdg.xdg_state_home() == HOME_DIR / ".local" / "state"
+
+
+def test_xdg_state_home_absolute(monkeypatch: MonkeyPatch) -> None:
+    """Test xdg_state_home when XDG_STATE_HOME is absolute path."""
+    monkeypatch.setenv("XDG_STATE_HOME", "/xdg_state_home")
+    assert xdg.xdg_state_home() == Path("/xdg_state_home")


### PR DESCRIPTION
Packaging for distros is pain, since pyxdg and xdg clash.
Just vendor the file for now and avoid problems.
