### PR TITLE
feat(db): Add command_meta and settings from argparser as json

### DIFF
--- a/src/gallia/command/base.py
+++ b/src/gallia/command/base.py
@@ -31,7 +31,7 @@ from gallia.plugins import load_transport
 from gallia.powersupply import PowerSupply, PowerSupplyURI
 from gallia.services.uds.core.exception import UDSException
 from gallia.transports import BaseTransport, TargetURI
-from gallia.utils import camel_to_snake
+from gallia.utils import camel_to_snake, dump_args
 
 
 @unique
@@ -494,6 +494,8 @@ class Scanner(AsyncScript, ABC):
             await self.db_handler.insert_run_meta(
                 script=sys.argv[0].split()[-1],
                 arguments=sys.argv[1:],
+                command_meta=msgspec.json.encode(self.run_meta.command_meta),
+                settings=dump_args(args),
                 start_time=datetime.now(timezone.utc).astimezone(),
                 path=self.artifacts_dir,
             )

--- a/src/gallia/db/handler.py
+++ b/src/gallia/db/handler.py
@@ -27,7 +27,7 @@ def bytes_repr(data: bytes) -> str:
     return bytes_repr_(data, False, None)
 
 
-schema_version = "2.0"
+schema_version = "2"
 
 DB_SCHEMA = f"""
 CREATE TABLE IF NOT EXISTS version (

--- a/src/gallia/utils.py
+++ b/src/gallia/utils.py
@@ -212,3 +212,13 @@ def lazy_import(name: str) -> ModuleType:
     sys.modules[name] = module
     loader.exec_module(module)
     return module
+
+
+def dump_args(args: Namespace) -> dict[str, str | int | float]:
+    settings = {}
+    for key, value in args.__dict__.items():
+        match value:
+            case str() | int() | float():
+                settings[key] = value
+
+    return settings


### PR DESCRIPTION
This PR adds two columns to the `run_meta` db table:
1) `command_meta`: same as the one in `META.json`
2) `settings`: key -> value pair of settings retrieved from the argparser

For settings from the argparser, only the follwing trivial types are currently supported: `str`, `int`, `float`.
Other, complex data types would need a custom json serializer, which is out of scope for now.
Unsupported data types are skipped to prevent any confusion. 

The DB schema version is increased to `2.0`