### PR TITLE
chore: Bump release number of dev branch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "gallia"
-version = "1.1.3"
+version = "1.2.0.dev0"
 description = "Extendable Pentesting Framework"
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
The master branch is usually ahead of the maintenance branch. Inform tools that it indeed is ahead it.