### PR TITLE
test xcp: revive xcp test script with CAN support

### DIFF
--- a/src/gallia/commands/__init__.py
+++ b/src/gallia/commands/__init__.py
@@ -17,6 +17,7 @@ from gallia.commands.primitive.uds.read_error_log import ReadErrorLogPrimitive
 from gallia.commands.primitive.uds.rmba import RMBAPrimitive
 from gallia.commands.primitive.uds.rtcl import RTCLPrimitive
 from gallia.commands.primitive.uds.send_pdu import SendPDUPrimitive
+from gallia.commands.primitive.uds.test_xcp import SimpleTestXCP
 from gallia.commands.primitive.uds.vin import VINPrimitive
 from gallia.commands.primitive.uds.wmba import WMBAPrimitive
 from gallia.commands.primitive.uds.write_by_identifier import WriteByIdentifierPrimitive
@@ -54,6 +55,7 @@ registry: list[type[BaseCommand]] = [
     WMBAPrimitive,
     VirtualECU,
     WriteByIdentifierPrimitive,
+    SimpleTestXCP,
 ]
 
 __all__ = [x.__name__ for x in registry]

--- a/src/gallia/commands/primitive/uds/test_xcp.py
+++ b/src/gallia/commands/primitive/uds/test_xcp.py
@@ -2,23 +2,52 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from argparse import Namespace
+from argparse import ArgumentParser, Namespace
 
 from gallia.command import Scanner
+from gallia.config import Config
 from gallia.plugins import load_transport
-from gallia.services.xcp import XCPService
-from gallia.utils import catch_and_log_exception
+from gallia.services.xcp import CANXCPSerivce, XCPService
+from gallia.transports.can import ISOTPTransport, RawCANTransport
+from gallia.utils import auto_int, catch_and_log_exception
 
 
 class SimpleTestXCP(Scanner):
     """Test XCP Slave"""
 
-    async def main(self, args: Namespace) -> None:
+    GROUP = "primitive"
+    COMMAND = "xcp"
+    SHORT_HELP = "XCP tester"
+
+    def __init__(self, parser: ArgumentParser, config: Config):
+        self.service: XCPService
+
+        super().__init__(parser, config)
+
+    def configure_parser(self) -> None:
+        self.parser.add_argument("--can-master", type=auto_int, default=None)
+        self.parser.add_argument("--can-slave", type=auto_int, default=None)
+
+    async def setup(self, args: Namespace) -> None:
         transport_type = load_transport(args.target)
         transport = await transport_type.connect(args.target)
-        service = XCPService(transport)
 
-        await catch_and_log_exception(service.connect)
-        await catch_and_log_exception(service.get_status)
-        await catch_and_log_exception(service.get_comm_mode_info)
-        await catch_and_log_exception(service.disconnect)
+        if isinstance(transport, RawCANTransport):
+            if args.can_master is None or args.can_slave is None:
+                self.parser.error(
+                    "For CAN interfaces, master and slave address are required!"
+                )
+
+            self.service = CANXCPSerivce(transport, args.can_master, args.can_slave)
+        elif isinstance(transport, ISOTPTransport):
+            self.parser.error("Use can-raw for CAN interfaces!")
+        else:
+            self.service = XCPService(transport)
+
+        await super().setup(args)
+
+    async def main(self, args: Namespace) -> None:
+        await catch_and_log_exception(self.service.connect)
+        await catch_and_log_exception(self.service.get_status)
+        await catch_and_log_exception(self.service.get_comm_mode_info)
+        await catch_and_log_exception(self.service.disconnect)


### PR DESCRIPTION
Currently the XCP primitive test tool is not exposed in gallia and only exists as an unreferenced file.
Furthermore it is lacking CAN support, as it makes use of the read() function, which is unsupported by the `can-raw` transport, which is however required for XCP on CAN communication.

Therefore, this Pull request tries to fix both issues, by exposing the scanner on the CLI and by adding a CAN specific subclass of the XCPService class. Its master and slave parameters are retrieved by the two new CLI parameters `--can-master` and `--can-slave` 