### PR TITLE
feat(scan-reset): Power cycle ECU after timeout to recover state

### DIFF
--- a/src/gallia/command/base.py
+++ b/src/gallia/command/base.py
@@ -597,7 +597,10 @@ class Scanner(AsyncScript, ABC):
             "--power-cycle",
             action=argparse.BooleanOptionalAction,
             default=self.config.get_value("gallia.scanner.power_cycle", False),
-            help="trigger a powercycle before starting the scan",
+            help=(
+                "use the configured power supply to power-cycle the ECU when needed "
+                "(e.g. before starting the scan, or to recover bad state during scanning)"
+            ),
         )
         group.add_argument(
             "--power-cycle-sleep",


### PR DESCRIPTION
This PR extends the `scan-reset` scanner to power cycle the ECU in case of timeout (e.g. because we triggered a power-down reset level).
A power supply must be configured, otherwise this is ignored.

TODO:
- [x] Power cycle only if `--power-cycle` is provided
- [x] catch only `asyncio.TimeoutError` and `ConnectionError`