### PR TITLE
fix: Remove auto-discovery of sessions from multiple scanners

### DIFF
--- a/src/gallia/commands/scan/uds/services.py
+++ b/src/gallia/commands/scan/uds/services.py
@@ -44,7 +44,7 @@ class ServicesScanner(UDSScanner):
             "--check-session",
             action="store_true",
             default=False,
-            help="check current session",
+            help="check current session; only takes affect if --sessions is given",
         )
         self.parser.add_argument(
             "--scan-response-ids",
@@ -73,6 +73,7 @@ class ServicesScanner(UDSScanner):
                   - 0x10-0x2f
                   - 0x01:0xf3,0x10-0x2f
                  Multiple session specific skips are separated by space.
+                 Only takes affect if --sessions is given.
                  """,
         )
 
@@ -82,103 +83,43 @@ class ServicesScanner(UDSScanner):
         found: dict[int, dict[int, Any]] = {}
 
         if args.sessions is None:
-            logger.info("No sessions specified, starting with session scan")
-            # Only until 0x80 because the eight bit is "SuppressResponse"
-            sessions = [
-                s
-                for s in range(1, 0x80)
-                if s not in args.skip or args.skip[s] is not None
-            ]
-            sessions = await self.ecu.find_sessions(sessions)
-            logger.result(f"Found {len(sessions)} sessions: {g_repr(sessions)}")
+            found[0] = await self.perform_scan(args)
         else:
             sessions = [
                 s
                 for s in args.sessions
                 if s not in args.skip or args.skip[s] is not None
             ]
+            logger.info(f"testing sessions {g_repr(sessions)}")
 
-        logger.info(f"testing sessions {g_repr(sessions)}")
+            # TODO: Unified shortened output necessary here
+            logger.info(f"skipping identifiers {reprlib.repr(args.skip)}")
 
-        # TODO: Unified shortened output necessary here
-        logger.info(f"skipping identifiers {reprlib.repr(args.skip)}")
-
-        for session in sessions:
-            logger.info(f"Changing to session {g_repr(session)}")
-            try:
-                resp: UDSResponse = await self.ecu.set_session(
-                    session, UDSRequestConfig(tags=["preparation"])
-                )
-            except (UDSException, RuntimeError) as e:  # FIXME why catch RuntimeError?
-                logger.warning(
-                    f"Could not complete session change to {g_repr(session)}: {g_repr(e)}; skipping session"
-                )
-                continue
-            if isinstance(resp, NegativeResponse):
-                logger.warning(
-                    f"Could not complete session change to {g_repr(session)}: {resp}; skipping session"
-                )
-                continue
-
-            found[session] = {}
-            logger.result(f"scanning in session {g_repr(session)}")
-
-            # Starts at 0x00, see first loop iteration.
-            sid = -1
-            while sid < 0xFF:
-                sid += 1
-                if sid & 0x40 and not args.scan_response_ids:
-                    continue
-
-                if session in args.skip and sid in args.skip[session]:
-                    logger.info(f"{g_repr(sid)}: skipped")
-                    continue
-
-                if args.check_session:
-                    if not await self.ecu.check_and_set_session(session):
-                        logger.error(
-                            f"Aborting scan on session {g_repr(session)}; current SID was {g_repr(sid)}"
-                        )
-                        break
-
-                for length_payload in [1, 2, 3, 5]:
-                    pdu = bytes([sid]) + bytes(length_payload)
-                    try:
-                        resp = await self.ecu.send_raw(
-                            pdu, config=UDSRequestConfig(tags=["ANALYZE"])
-                        )
-                    except asyncio.TimeoutError:
-                        logger.info(f"{g_repr(sid)}: timeout")
-                        continue
-                    except MalformedResponse as e:
-                        logger.warning(
-                            f"{g_repr(sid)}: {e!r} occurred, this needs to be investigated!"
-                        )
-                        continue
-                    except Exception as e:
-                        logger.info(f"{g_repr(sid)}: {e!r} occurred")
-                        await self.ecu.reconnect()
-                        continue
-
-                    if isinstance(resp, NegativeResponse) and resp.response_code in [
-                        UDSErrorCodes.serviceNotSupported,
-                        UDSErrorCodes.serviceNotSupportedInActiveSession,
-                    ]:
-                        logger.info(f"{g_repr(sid)}: not supported [{resp}]")
-                        break
-
-                    if isinstance(resp, NegativeResponse) and resp.response_code in [
-                        UDSErrorCodes.incorrectMessageLengthOrInvalidFormat,
-                    ]:
-                        continue
-
-                    logger.result(
-                        f"{g_repr(sid)}: available in session {g_repr(session)}: {resp}"
+            for session in sessions:
+                logger.info(f"Changing to session {g_repr(session)}")
+                try:
+                    resp: UDSResponse = await self.ecu.set_session(
+                        session, UDSRequestConfig(tags=["preparation"])
                     )
-                    found[session][sid] = resp
-                    break
+                except (
+                    UDSException,
+                    RuntimeError,
+                ) as e:  # FIXME why catch RuntimeError?
+                    logger.warning(
+                        f"Could not complete session change to {g_repr(session)}: {g_repr(e)}; skipping session"
+                    )
+                    continue
+                if isinstance(resp, NegativeResponse):
+                    logger.warning(
+                        f"Could not complete session change to {g_repr(session)}: {resp}; skipping session"
+                    )
+                    continue
 
-            await self.ecu.leave_session(session)
+                logger.result(f"scanning in session {g_repr(session)}")
+
+                found[session] = await self.perform_scan(args)
+
+                await self.ecu.leave_session(session)
 
         for key, value in found.items():
             logger.result(f"findings in session 0x{key:02X}:")
@@ -190,3 +131,65 @@ class ServicesScanner(UDSScanner):
                     )
                 except Exception:
                     logger.result(f"  [{g_repr(sid)}] vendor specific sid: {data}")
+
+    async def perform_scan(
+        self, args: Namespace, session: None | int = None
+    ) -> dict[int, Any]:
+        result: dict[int, Any] = {}
+
+        # Starts at 0x00, see first loop iteration.
+        sid = -1
+        while sid < 0xFF:
+            sid += 1
+            if sid & 0x40 and not args.scan_response_ids:
+                continue
+
+            if session in args.skip and sid in args.skip[session]:
+                logger.info(f"{g_repr(sid)}: skipped")
+                continue
+
+            if session is not None and args.check_session:
+                if not await self.ecu.check_and_set_session(session):
+                    logger.error(
+                        f"Aborting scan on session {g_repr(session)}; current SID was {g_repr(sid)}"
+                    )
+                    break
+
+            for length_payload in [1, 2, 3, 5]:
+                pdu = bytes([sid]) + bytes(length_payload)
+                try:
+                    resp = await self.ecu.send_raw(
+                        pdu, config=UDSRequestConfig(tags=["ANALYZE"])
+                    )
+                except asyncio.TimeoutError:
+                    logger.info(f"{g_repr(sid)}: timeout")
+                    continue
+                except MalformedResponse as e:
+                    logger.warning(
+                        f"{g_repr(sid)}: {e!r} occurred, this needs to be investigated!"
+                    )
+                    continue
+                except Exception as e:
+                    logger.info(f"{g_repr(sid)}: {e!r} occurred")
+                    await self.ecu.reconnect()
+                    continue
+
+                if isinstance(resp, NegativeResponse) and resp.response_code in [
+                    UDSErrorCodes.serviceNotSupported,
+                    UDSErrorCodes.serviceNotSupportedInActiveSession,
+                ]:
+                    logger.info(f"{g_repr(sid)}: not supported [{resp}]")
+                    break
+
+                if isinstance(resp, NegativeResponse) and resp.response_code in [
+                    UDSErrorCodes.incorrectMessageLengthOrInvalidFormat,
+                ]:
+                    continue
+
+                logger.result(
+                    f"{g_repr(sid)}: available in session {g_repr(session)}: {resp}"
+                )
+                result[sid] = resp
+                break
+
+        return result

--- a/src/gallia/services/uds/ecu.py
+++ b/src/gallia/services/uds/ecu.py
@@ -246,21 +246,6 @@ class ECU(UDSClient):
             await self.reconnect()
         return True
 
-    async def find_sessions(self, search: list[int], max_retry: int = 4) -> list[int]:
-        sessions = []
-        for sid in search:
-            try:
-                resp = await self.set_session(
-                    sid, config=UDSRequestConfig(max_retry=max_retry)
-                )
-                if isinstance(resp, service.NegativeResponse):
-                    continue
-            except Exception:
-                continue
-            sessions.append(sid)
-            await self.leave_session(sid)
-        return sessions
-
     async def set_session(
         self,
         level: int,


### PR DESCRIPTION
Since we have a dedicated scanner for identifying available sessions it does not make sense to implement a low-effort variant of sessions-scanning for multiple scanners with totally different tasks.

Moreover, this change allows to run these scanners without requiring the availability of DiagnosticSessionControl, as long as no --sessions flag is given.