### PR TITLE
fix hanging tests due to a python bug

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1696227680,
-        "narHash": "sha256-G6Lt2qzQGl3NrI3WS4aJ40eMZRxgnhrbblnftBM3aGM=",
+        "lastModified": 1702037461,
+        "narHash": "sha256-5G9qC12Fwe4f/zTeP6xAJJ8vJ9H7Vc1nodvMTeu2X/s=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b56f06f3e8c6f48973a43765f4b02c756ba30da4",
+        "rev": "6a6d3373898c5fbd3ab8626e965f8b80cc932bb4",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -14,8 +14,8 @@
       devShell.x86_64-linux = pkgs.mkShell {
         buildInputs = with pkgs; [ 
           poetry
-          python310
           python311
+          python312
         ];
         shellHook = ''
           LD_LIBRARY_PATH=${pkgs.lib.makeLibraryPath [stdenv.cc.cc]}

--- a/tests/test_transports.py
+++ b/tests/test_transports.py
@@ -38,9 +38,8 @@ class TCPServer:
     async def accept(self) -> TCPTransport:
         return await self.queue.get()
 
-    async def close(self) -> None:
+    def close(self) -> None:
         self.server.close()
-        await self.server.wait_closed()
 
 
 async def _echo_test(
@@ -66,7 +65,7 @@ async def tcp_server() -> AsyncIterator[TCPServer]:
     tcp_server = TCPServer()
     await tcp_server.listen(listen_target)
     yield tcp_server
-    await tcp_server.close()
+    tcp_server.close()
 
 
 @pytest.mark.asyncio
@@ -127,7 +126,7 @@ async def test_tcp_linesep_request(tcp_server: TCPServer) -> None:
 @pytest.mark.asyncio
 async def test_tcp_timeout(tcp_server: TCPServer) -> None:
     client = await TCPLinesTransport.connect(TargetURI("tcp-lines://127.0.0.1:1234"))
-    _ = await tcp_server.accept()
+    await tcp_server.accept()
 
     with pytest.raises(asyncio.TimeoutError):
         await client.request(b"hello", timeout=0.5)


### PR DESCRIPTION
- flake.lock: Update
- chore: Add python 3.12 to flake.nix
- chore: Fix deprecation warning
- fix(tests): Fix hanging tests

The exceptions in the Python 3.12 tests are a regression and will be fixed in 3.12.1; nothing to do here: https://github.com/python/cpython/issues/109538
