### PR TITLE
cherry picked fixes from #474

### DIFF
--- a/src/gallia/commands/scan/uds/services.py
+++ b/src/gallia/commands/scan/uds/services.py
@@ -169,10 +169,6 @@ class ServicesScanner(UDSScanner):
                         f"{g_repr(sid)}: {e!r} occurred, this needs to be investigated!"
                     )
                     continue
-                except Exception as e:
-                    logger.info(f"{g_repr(sid)}: {e!r} occurred")
-                    await self.ecu.reconnect()
-                    continue
 
                 if isinstance(resp, NegativeResponse) and resp.response_code in [
                     UDSErrorCodes.serviceNotSupported,

--- a/src/gallia/dumpcap.py
+++ b/src/gallia/dumpcap.py
@@ -164,11 +164,12 @@ class Dumpcap:
         return args
 
     @staticmethod
-    async def _eth_cmd(target_ip: str) -> list[str]:
+    async def _eth_cmd(target_ip: str) -> list[str] | None:
         try:
             host, port = split_host_port(target_ip)
         except Exception as e:
-            raise ValueError(f"Invalid argument for target ip: {target_ip}; {e}") from e
+            logger.error(f"Invalid argument for target ip: {target_ip}; {e}")
+            return None
 
         if proxy := os.getenv("all_proxy"):
             url = urlparse(proxy)

--- a/src/gallia/log.py
+++ b/src/gallia/log.py
@@ -299,7 +299,7 @@ def add_stderr_log_handler(
 
 def add_zst_log_handler(
     logger_name: str, filepath: Path, file_log_level: Loglevel
-) -> None:
+) -> logging.Handler:
     queue: Queue[Any] = Queue()
     logger = get_logger(logger_name)
     logger.addHandler(QueueHandler(queue))
@@ -318,6 +318,7 @@ def add_zst_log_handler(
     )
     queue_listener.start()
     atexit.register(queue_listener.stop)
+    return zstd_handler
 
 
 class _PenlogRecordV1(msgspec.Struct, omit_defaults=True):


### PR DESCRIPTION
- fix(scan-services): Remove too broad except block
- feat(log): Expose logging QueueListeners in cls object
- fix(dumpcap): Adapt error handling of default eth case
- fix(tester-present): Terminate tester-present worker properly
