### PR TITLE
dump-seeds: remove arbitrary default duration

### DIFF
--- a/src/gallia/commands/scan/uds/sa_dump_seeds.py
+++ b/src/gallia/commands/scan/uds/sa_dump_seeds.py
@@ -72,10 +72,10 @@ class SASeedsDumper(UDSScanner):
         )
         self.parser.add_argument(
             "--duration",
-            default=12 * 60,
+            default=0,
             type=float,
             metavar="FLOAT",
-            help="Run script for N minutes; zero or negative for infinite runtime",
+            help="Run script for N minutes; zero or negative for infinite runtime (default)",
         )
         self.parser.add_argument(
             "--data-record",


### PR DESCRIPTION
Remove the arbitrary default of 12 hours, by default it should run until halted.
While on could argue, that this bears the risk of filling up the disk with random numbers, there still is not real reason for this 12h value, because in practice this could take hours to months depending on the output rate of the device under test and the remaining capacity of the system.