### PR TITLE
Add relative timings to cursed hr + lift restrictions on number of function arguments for linters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,7 @@ ignore = [
     "PLR2004",  # magic value used in comparison
     "PLR0911",  # too many return statements
     "PLR0912",  # too many branches
+    "PLR0913",  # too many arguments to function call
     "PLR0915",  # too many statements
     "PLC1901",  # empty string is falsey
 ]

--- a/src/cursed_hr/cursed_hr.py
+++ b/src/cursed_hr/cursed_hr.py
@@ -117,9 +117,6 @@ class EntryCache:
             return self.entries[entry_number]
 
     def _load_entry(self, entry_number: int) -> None:
-        self.file.seek(self.entry_positions[entry_number])
-        line = self.file.readline()
-
         if len(self.entries) + len(self.old_entries) >= self.cache_size:
             self.old_entries = self.entries
             self.entries = {}
@@ -127,6 +124,9 @@ class EntryCache:
         try:
             self.entries[entry_number] = self.old_entries.pop(entry_number)
         except KeyError:
+            self.file.seek(self.entry_positions[entry_number])
+            line = self.file.readline()
+
             try:
                 self.entries[entry_number] = PenlogEntry.parse_json(line)
             except (json.decoder.JSONDecodeError, TypeError):


### PR DESCRIPTION
Possibility to toggle between timestamps (as already the case) and timings relative to a reference entry (by default: first entry in the json, independent of priority or filter)

Toggling is possible with `t` while the program is running or via the `--relative-timings` CLI option.
The reference entry can be set by pressing 'z' when the cursor is at the corresponding line.

Additionally, this PR also contains a commit which should reduce the number of unncessary file access calls.

Also as agreed with @rumpelsepp this PR lifts the restriction of allowing only five arguments for a function, because it came up again here, which IMHO is more often than not just annoying but not really leads to a better codebase.