### PR TITLE
fix(log): Fix wrong timezone in logfiles

### DIFF
--- a/src/gallia/log.py
+++ b/src/gallia/log.py
@@ -15,6 +15,7 @@ import shutil
 import socket
 import sys
 import tempfile
+import time
 import traceback
 from collections.abc import Iterator
 from dataclasses import dataclass
@@ -32,7 +33,8 @@ if TYPE_CHECKING:
     from logging import _ExcInfoType
 
 
-tz = datetime.datetime.now(datetime.UTC).tzinfo
+gmt_offset = time.localtime().tm_gmtoff
+tz = datetime.timezone(datetime.timedelta(seconds=gmt_offset))
 
 
 @unique


### PR DESCRIPTION
Since 939f26764cbf1e9fc274d912f85d31e0b3235cba the logfiles contained
the UTC timezone which is wrong. This patch changes the code such that
the timezone is set correctly to the **local** timezone of the current
platform.
