### PR TITLE
fix(logger): use name instead of file for logger base

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -30,7 +30,7 @@ from gallia.log import get_logger, setup_logging, Loglevel
 # The logfile's loglevel is Loglevel.DEBUG.
 # It can be set with the keyword argument file_level.
 setup_logging(level=Loglevel.INFO)
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 logger.info("hello world")
 logger.debug("hello debug")
 ```

--- a/src/gallia/command/base.py
+++ b/src/gallia/command/base.py
@@ -68,7 +68,7 @@ class RunMeta(msgspec.Struct):
         return msgspec.json.encode(self).decode()
 
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 if sys.platform.startswith("linux") or sys.platform == "darwin":

--- a/src/gallia/command/uds.py
+++ b/src/gallia/command/uds.py
@@ -15,7 +15,7 @@ from gallia.services.uds.core.service import NegativeResponse, UDSResponse
 from gallia.services.uds.ecu import ECU
 from gallia.services.uds.helpers import raise_for_error
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 class UDSScanner(Scanner):

--- a/src/gallia/commands/discover/doip.py
+++ b/src/gallia/commands/discover/doip.py
@@ -34,7 +34,7 @@ from gallia.transports.doip import (
     VehicleAnnouncementMessage,
 )
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 class DoIPDiscoverer(AsyncScript):

--- a/src/gallia/commands/discover/find_xcp.py
+++ b/src/gallia/commands/discover/find_xcp.py
@@ -16,7 +16,7 @@ from gallia.services.uds.core.utils import bytes_repr, g_repr
 from gallia.transports import RawCANTransport, TargetURI
 from gallia.utils import auto_int, can_id_repr
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 class FindXCP(AsyncScript):

--- a/src/gallia/commands/discover/uds/isotp.py
+++ b/src/gallia/commands/discover/uds/isotp.py
@@ -16,7 +16,7 @@ from gallia.services.uds.core.utils import g_repr
 from gallia.transports import ISOTPTransport, RawCANTransport, TargetURI
 from gallia.utils import auto_int, can_id_repr, write_target_list
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 class IsotpDiscoverer(UDSDiscoveryScanner):

--- a/src/gallia/commands/fuzz/uds/pdu.py
+++ b/src/gallia/commands/fuzz/uds/pdu.py
@@ -20,7 +20,7 @@ from gallia.services.uds.helpers import suggests_identifier_not_supported
 from gallia.transports import RawCANTransport, TargetURI
 from gallia.utils import auto_int
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 class PDUFuzzer(UDSScanner):

--- a/src/gallia/commands/primitive/uds/dtc.py
+++ b/src/gallia/commands/primitive/uds/dtc.py
@@ -19,7 +19,7 @@ from gallia.services.uds.core.service import NegativeResponse
 from gallia.services.uds.core.utils import g_repr
 from gallia.utils import auto_int
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 class DTCPrimitive(UDSScanner):

--- a/src/gallia/commands/primitive/uds/ecu_reset.py
+++ b/src/gallia/commands/primitive/uds/ecu_reset.py
@@ -11,7 +11,7 @@ from gallia.services.uds import NegativeResponse, UDSResponse
 from gallia.services.uds.core.utils import g_repr
 from gallia.utils import auto_int
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 class ECUResetPrimitive(UDSScanner):

--- a/src/gallia/commands/primitive/uds/iocbi.py
+++ b/src/gallia/commands/primitive/uds/iocbi.py
@@ -12,7 +12,7 @@ from gallia.services.uds import NegativeResponse
 from gallia.services.uds.core.utils import g_repr
 from gallia.utils import auto_int
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 class IOCBIPrimitive(UDSScanner):

--- a/src/gallia/commands/primitive/uds/pdu.py
+++ b/src/gallia/commands/primitive/uds/pdu.py
@@ -19,7 +19,7 @@ from gallia.services.uds.core.service import RawRequest, RawResponse
 from gallia.services.uds.helpers import raise_for_error
 from gallia.utils import auto_int
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 class SendPDUPrimitive(UDSScanner):

--- a/src/gallia/commands/primitive/uds/ping.py
+++ b/src/gallia/commands/primitive/uds/ping.py
@@ -11,7 +11,7 @@ from gallia.log import get_logger
 from gallia.services.uds.core.service import NegativeResponse
 from gallia.utils import auto_int
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 class PingPrimitive(UDSScanner):

--- a/src/gallia/commands/primitive/uds/rdbi.py
+++ b/src/gallia/commands/primitive/uds/rdbi.py
@@ -10,7 +10,7 @@ from gallia.log import get_logger
 from gallia.services.uds.core.service import NegativeResponse
 from gallia.utils import auto_int
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 class ReadByIdentifierPrimitive(UDSScanner):

--- a/src/gallia/commands/primitive/uds/rmba.py
+++ b/src/gallia/commands/primitive/uds/rmba.py
@@ -11,7 +11,7 @@ from gallia.services.uds import NegativeResponse
 from gallia.services.uds.core.utils import g_repr
 from gallia.utils import auto_int
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 class RMBAPrimitive(UDSScanner):

--- a/src/gallia/commands/primitive/uds/rtcl.py
+++ b/src/gallia/commands/primitive/uds/rtcl.py
@@ -14,7 +14,7 @@ from gallia.services.uds.core.service import RoutineControlResponse
 from gallia.services.uds.core.utils import g_repr
 from gallia.utils import auto_int
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 class RTCLPrimitive(UDSScanner):

--- a/src/gallia/commands/primitive/uds/vin.py
+++ b/src/gallia/commands/primitive/uds/vin.py
@@ -8,7 +8,7 @@ from gallia.command import UDSScanner
 from gallia.log import get_logger
 from gallia.services.uds.core.service import NegativeResponse
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 class VINPrimitive(UDSScanner):

--- a/src/gallia/commands/primitive/uds/wdbi.py
+++ b/src/gallia/commands/primitive/uds/wdbi.py
@@ -12,7 +12,7 @@ from gallia.log import get_logger
 from gallia.services.uds import NegativeResponse, UDSResponse
 from gallia.utils import auto_int
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 class WriteByIdentifierPrimitive(UDSScanner):

--- a/src/gallia/commands/primitive/uds/wmba.py
+++ b/src/gallia/commands/primitive/uds/wmba.py
@@ -13,7 +13,7 @@ from gallia.services.uds import NegativeResponse
 from gallia.services.uds.core.utils import g_repr
 from gallia.utils import auto_int
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 class WMBAPrimitive(UDSScanner):

--- a/src/gallia/commands/scan/uds/identifiers.py
+++ b/src/gallia/commands/scan/uds/identifiers.py
@@ -21,7 +21,7 @@ from gallia.services.uds.core.utils import g_repr, service_repr
 from gallia.services.uds.helpers import suggests_service_not_supported
 from gallia.utils import ParseSkips, auto_int
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 class ScanIdentifiers(UDSScanner):

--- a/src/gallia/commands/scan/uds/memory.py
+++ b/src/gallia/commands/scan/uds/memory.py
@@ -12,7 +12,7 @@ from gallia.services.uds import NegativeResponse, UDSErrorCodes, UDSRequestConfi
 from gallia.services.uds.core.utils import g_repr, uds_memory_parameters
 from gallia.utils import auto_int
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 class MemoryFunctionsScanner(UDSScanner):

--- a/src/gallia/commands/scan/uds/reset.py
+++ b/src/gallia/commands/scan/uds/reset.py
@@ -18,7 +18,7 @@ from gallia.services.uds.core.utils import g_repr
 from gallia.services.uds.helpers import suggests_sub_function_not_supported
 from gallia.utils import ParseSkips, auto_int
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 class ResetScanner(UDSScanner):

--- a/src/gallia/commands/scan/uds/sa_dump_seeds.py
+++ b/src/gallia/commands/scan/uds/sa_dump_seeds.py
@@ -17,7 +17,7 @@ from gallia.services.uds import NegativeResponse, UDSRequestConfig
 from gallia.services.uds.core.utils import g_repr
 from gallia.utils import auto_int
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 class SASeedsDumper(UDSScanner):

--- a/src/gallia/commands/scan/uds/services.py
+++ b/src/gallia/commands/scan/uds/services.py
@@ -19,7 +19,7 @@ from gallia.services.uds.core.exception import MalformedResponse, UDSException
 from gallia.services.uds.core.utils import g_repr
 from gallia.utils import ParseSkips, auto_int
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 class ServicesScanner(UDSScanner):

--- a/src/gallia/commands/scan/uds/sessions.py
+++ b/src/gallia/commands/scan/uds/sessions.py
@@ -20,7 +20,7 @@ from gallia.services.uds.core.service import DiagnosticSessionControlResponse
 from gallia.services.uds.core.utils import g_repr
 from gallia.utils import auto_int
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 class SessionsScanner(UDSScanner):

--- a/src/gallia/commands/script/vecu.py
+++ b/src/gallia/commands/script/vecu.py
@@ -23,7 +23,7 @@ from gallia.transports import TargetURI, TransportScheme
 dynamic_attr_prefix = "dynamic_attr_"
 
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 class VirtualECU(AsyncScript):

--- a/src/gallia/db/handler.py
+++ b/src/gallia/db/handler.py
@@ -131,7 +131,7 @@ GROUP BY ru.id;
 INSERT OR IGNORE INTO version VALUES('main', '{schema_version}');
 """
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 class DBHandler:

--- a/src/gallia/dumpcap.py
+++ b/src/gallia/dumpcap.py
@@ -20,7 +20,7 @@ from gallia.log import get_logger
 from gallia.transports import TargetURI, TransportScheme
 from gallia.utils import auto_int, split_host_port
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 if sys.platform.startswith("linux") or sys.platform == "darwin":

--- a/src/gallia/powersupply.py
+++ b/src/gallia/powersupply.py
@@ -14,7 +14,7 @@ from opennetzteil.netzteil import BaseNetzteil
 from gallia.log import get_logger
 from gallia.transports import TargetURI
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 class PowerSupplyURI(TargetURI):

--- a/src/gallia/services/uds/core/client.py
+++ b/src/gallia/services/uds/core/client.py
@@ -30,7 +30,7 @@ class UDSRequestConfig:
     tags: list[str] | None = None
 
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 class UDSClient:

--- a/src/gallia/services/uds/core/service.py
+++ b/src/gallia/services/uds/core/service.py
@@ -37,7 +37,7 @@ from gallia.services.uds.core.utils import (
     uds_memory_parameters,
 )
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 # ****************
 # * Base classes *

--- a/src/gallia/services/uds/ecu.py
+++ b/src/gallia/services/uds/ecu.py
@@ -45,7 +45,7 @@ class ECUState:
         return f'{type(self).__name__}({", ".join(f"{key}={g_repr(value)}" for key, value in self.__dict__.items())})'
 
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 class ECU(UDSClient):

--- a/src/gallia/services/uds/server.py
+++ b/src/gallia/services/uds/server.py
@@ -30,7 +30,7 @@ from gallia.services.uds.core.utils import bytes_repr, int_repr, service_repr, t
 from gallia.services.uds.ecu import ECUState
 from gallia.transports import TargetURI
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 class UDSServer(ABC):

--- a/src/gallia/services/xcp/__init__.py
+++ b/src/gallia/services/xcp/__init__.py
@@ -12,7 +12,7 @@ from gallia.services.xcp import types
 from gallia.transports import BaseTransport
 from gallia.transports.can import RawCANTransport
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 class XCPService:

--- a/src/gallia/transports/base.py
+++ b/src/gallia/transports/base.py
@@ -13,7 +13,7 @@ from gallia.log import get_logger
 from gallia.transports.schemes import TransportScheme
 from gallia.utils import join_host_port
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 class TargetURI:

--- a/src/gallia/transports/can.py
+++ b/src/gallia/transports/can.py
@@ -18,7 +18,7 @@ from gallia.log import get_logger
 from gallia.transports.base import BaseTransport, TargetURI
 from gallia.utils import auto_int
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 CANFD_MTU = 72
 CAN_MTU = 16

--- a/src/gallia/transports/doip.py
+++ b/src/gallia/transports/doip.py
@@ -17,7 +17,7 @@ from gallia.log import get_logger
 from gallia.transports.base import BaseTransport, TargetURI
 from gallia.utils import auto_int
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 @unique

--- a/src/gallia/transports/isotp.py
+++ b/src/gallia/transports/isotp.py
@@ -17,7 +17,7 @@ from gallia.log import get_logger
 from gallia.transports.base import BaseTransport, TargetURI
 from gallia.utils import auto_int
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 # Socket Constants not available in the socket module,
 # see linux/can/isotp.h

--- a/src/gallia/transports/tcp.py
+++ b/src/gallia/transports/tcp.py
@@ -10,7 +10,7 @@ from typing import Self
 from gallia.log import get_logger
 from gallia.transports.base import BaseTransport, LinesTransportMixin, TargetURI
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 class TCPTransport(BaseTransport, scheme="tcp"):

--- a/src/gallia/transports/unix.py
+++ b/src/gallia/transports/unix.py
@@ -11,7 +11,7 @@ assert sys.platform.startswith("linux"), "unsupported platform"
 from gallia.log import get_logger
 from gallia.transports.base import BaseTransport, LinesTransportMixin, TargetURI
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 class UnixTransport(BaseTransport, scheme="unix"):


### PR DESCRIPTION
Fixup for #556
Unfortunately, `__file__` does not work, because it returns the full path to the source file (eg. `/path-to-venv/gallia/...`) and the logger name is expected to be a dot-separated tree with `gallia` as base (because we filter on that).

I propose to use the `__name__` variable for the logger name, it starts with `gallia.`.