### PR TITLE
feat: Expose the response pending timeout to CLI and config

### DIFF
--- a/src/gallia/command/uds.py
+++ b/src/gallia/command/uds.py
@@ -62,6 +62,13 @@ class UDSScanner(Scanner):
             help="Timeout value to wait for a response from the ECU",
         )
         group.add_argument(
+            "--pending-timeout",
+            default=self.config.get_value("gallia.protocols.uds.pending_timeout", 0.5),
+            type=float,
+            metavar="SECONDS",
+            help="Timeout value to resolve a response pending error",
+        )
+        group.add_argument(
             "--max-retries",
             default=self.config.get_value("gallia.protocols.uds.max_retries", 3),
             type=int,
@@ -121,6 +128,7 @@ class UDSScanner(Scanner):
             self.transport,
             timeout=args.timeout,
             max_retry=args.max_retries,
+            pending_timeout=args.pending_timeout,
             power_supply=self.power_supply,
         )
 

--- a/src/gallia/services/uds/ecu.py
+++ b/src/gallia/services/uds/ecu.py
@@ -62,9 +62,15 @@ class ECU(UDSClient):
         transport: BaseTransport,
         timeout: float,
         max_retry: int = 1,
+        pending_timeout: float = 0.5,
         power_supply: PowerSupply | None = None,
     ) -> None:
-        super().__init__(transport, timeout, max_retry)
+        super().__init__(
+            transport=transport,
+            timeout=timeout,
+            max_retry=max_retry,
+            pending_timeout=pending_timeout,
+        )
         self.tester_present_task: Task[None] | None = None
         self.tester_present_interval: float | None = None
         self.power_supply = power_supply


### PR DESCRIPTION
When using FlexRay the ISO-TP layer might be too slow for the UDS stack.
In our setup the UDS stack timeouted before the ISO-TP code was ready
with resolving a response pending.

This patch exposes the timeout value in order to be able to configure
this problem away.
