### PR TITLE
feat: Add additional logging tags for protocol information

### DIFF
--- a/src/gallia/dissect/__init__.py
+++ b/src/gallia/dissect/__init__.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: AISEC Pentesting Team
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Literal, NotRequired, TypeAlias, TypedDict
+
+from gallia.services.uds.core.service import UDSRequest, UDSResponse
+
+
+@dataclass
+class Field:
+    name: str
+    raw_data: bytes
+    dissected_data: str
+
+
+class BaseDissector(ABC):
+    PROTO: str = ""
+
+    def __init_subclass__(
+        cls,
+        /,
+        proto: str,
+        **kwargs: Any,
+    ) -> None:
+        super().__init_subclass__(**kwargs)
+        cls.PROTO = proto
+
+    @abstractmethod
+    def dissect(self, data: bytes, iotype: str | None = None) -> list[Field]: ...
+
+
+class UDSDissector(BaseDissector, proto="uds"):
+    def dissect(self, data: bytes, iotype: str | None = None) -> list[Field]:
+        if data[0] & 0b01000000:
+            dissected_data = repr(UDSResponse.parse_dynamic(data))
+            name = "uds response"
+        else:
+            dissected_data = repr(UDSRequest.parse_dynamic(data))
+            name = "uds request"
+
+        return [Field(name=name, raw_data=data, dissected_data=dissected_data)]
+
+
+# TODO: Can the PROTO attribute be used?
+registry: dict[str, BaseDissector] = {"uds": UDSDissector()}

--- a/src/gallia/log.py
+++ b/src/gallia/log.py
@@ -24,7 +24,7 @@ from logging.handlers import QueueHandler, QueueListener
 from pathlib import Path
 from queue import Queue
 from types import TracebackType
-from typing import TYPE_CHECKING, Any, BinaryIO, Self, TextIO, TypeAlias, cast
+from typing import TYPE_CHECKING, Any, BinaryIO, Literal, Self, TextIO, TypeAlias, cast
 
 import msgspec
 import zstandard
@@ -822,3 +822,21 @@ logging.setLoggerClass(Logger)
 
 def get_logger(name: str) -> Logger:
     return cast(Logger, logging.getLogger(name))
+
+
+def log_io(
+    logger: Logger,
+    iotype: Literal["read", "write"],
+    proto: str,
+    data: bytes,
+    tags: list[str] | None = None,
+    trace: bool = False,
+) -> None:
+    # tags without "=" are deprecated
+    t = [f"=io={iotype}", "encoding=hex", f"proto={proto}", iotype]
+    if tags is not None:
+        t += tags
+    if trace:
+        logger.trace(data.hex(), extra={"tags": t})
+    else:
+        logger.debug(data.hex(), extra={"tags": t})

--- a/src/gallia/transports/hsfz.py
+++ b/src/gallia/transports/hsfz.py
@@ -15,7 +15,7 @@ from typing import Any, Self
 from pydantic import BaseModel, field_validator
 
 from gallia.log import get_logger
-from gallia.transports.base import BaseTransport, TargetURI
+from gallia.transports.base import BaseTransport, TargetURI, log_io
 from gallia.utils import auto_int
 
 logger = get_logger(__name__)
@@ -357,7 +357,9 @@ class HSFZTransport(BaseTransport, scheme="hsfz"):
         timeout: float | None = None,
         tags: list[str] | None = None,
     ) -> bytes:
-        return await asyncio.wait_for(self._conn.read_diag_request(), timeout)
+        data = await asyncio.wait_for(self._conn.read_diag_request(), timeout)
+        log_io(logger, "read", "hsfz", data, tags, trace=True)
+        return data
 
     async def write(
         self,
@@ -366,4 +368,5 @@ class HSFZTransport(BaseTransport, scheme="hsfz"):
         tags: list[str] | None = None,
     ) -> int:
         await asyncio.wait_for(self._conn.write_diag_request(data), timeout)
+        log_io(logger, "write", "hsfz", data, tags, trace=True)
         return len(data)

--- a/src/gallia/transports/isotp.py
+++ b/src/gallia/transports/isotp.py
@@ -14,7 +14,7 @@ assert sys.platform == "linux", "unsupported platform"
 from pydantic import BaseModel, field_validator
 
 from gallia.log import get_logger
-from gallia.transports.base import BaseTransport, TargetURI
+from gallia.transports.base import BaseTransport, TargetURI, log_io
 from gallia.utils import auto_int
 
 logger = get_logger(__name__)
@@ -182,7 +182,7 @@ class ISOTPTransport(BaseTransport, scheme="isotp"):
         timeout: float | None = None,
         tags: list[str] | None = None,
     ) -> int:
-        self.log_io(logger, "write", "isotp", data, tags, trace=True)
+        log_io(logger, "write", "isotp", data, tags, trace=True)
 
         loop = asyncio.get_running_loop()
         await asyncio.wait_for(loop.sock_sendall(self._sock, data), timeout)
@@ -198,7 +198,7 @@ class ISOTPTransport(BaseTransport, scheme="isotp"):
             if e.errno == errno.EILSEQ:
                 raise BrokenPipeError(f"invalid consecutive frame numbers: {e}") from e
             raise e
-        self.log_io(logger, "read", "isotp", data, tags, trace=True)
+        log_io(logger, "read", "isotp", data, tags, trace=True)
         return data
 
     async def close(self) -> None:

--- a/src/gallia/transports/isotp.py
+++ b/src/gallia/transports/isotp.py
@@ -182,8 +182,7 @@ class ISOTPTransport(BaseTransport, scheme="isotp"):
         timeout: float | None = None,
         tags: list[str] | None = None,
     ) -> int:
-        t = tags + ["write"] if tags is not None else ["write"]
-        logger.trace(data.hex(), extra={"tags": t})
+        self.log_io(logger, "write", "isotp", data, tags, trace=True)
 
         loop = asyncio.get_running_loop()
         await asyncio.wait_for(loop.sock_sendall(self._sock, data), timeout)
@@ -199,7 +198,7 @@ class ISOTPTransport(BaseTransport, scheme="isotp"):
             if e.errno == errno.EILSEQ:
                 raise BrokenPipeError(f"invalid consecutive frame numbers: {e}") from e
             raise e
-        logger.trace(data.hex(), extra={"tags": tags})
+        self.log_io(logger, "read", "isotp", data, tags, trace=True)
         return data
 
     async def close(self) -> None:


### PR DESCRIPTION
This MR adds the following; currently DRAFT for experiments:

* standardize logging tags:
  * `io={TYPE}`; `TYPE` is either `read` or `write`
  * `proto={PROTO}`; `PROTO` is one of the supported protocols in gallia, e.g. `uds` or `doip`.
  * `encoding={ENCODING}`; optional; `ENCODING` could be `hex` or `base64`
* add a dissector API
  * a dissector could be used in the `hr` commands to interpret the tagged messages

The motivation of this is, we have currently a ["works somehow" dissector](https://github.com/Fraunhofer-AISEC/gallia/blob/9ac497585ded867ddf1de8eafcbf0f598b2bf2f9/src/cursed_hr/cursed_hr.py#L626-L642) in `cursed_hr` for UDS. This dissector uses a best effort heuristic to detect UDS messages. However, this is not useful for messages of other types.

gallia recently gained FlexRay support and a standardized dissection API in our `hr` commands would help everybody. For instance, for FlexRay there is already [an own tool](https://github.com/Fraunhofer-AISEC/gallia/blob/9ac497585ded867ddf1de8eafcbf0f598b2bf2f9/src/gallia/commands/script/flexray.py#L43-L54) to help debugging.

So, this MR is an attempt to standardize dissection in our toolchain by adding metadata to our logfiles and an extendable API for `hr`.


Open Questions:

* API for dissector: How should protocol metadata be handled? e.g. FlexRay Slot ID or CAN IDs?