### PR TITLE
Remove volatile-info in favor of a bottom progress bar (cf. apt install)

### DIFF
--- a/src/gallia/cli/gallia.py
+++ b/src/gallia/cli/gallia.py
@@ -185,7 +185,6 @@ def parse_and_run(
     if setup_log:
         setup_logging(
             level=get_log_level(config.verbose),
-            no_volatile_info=not config.volatile_info,
         )
 
     sys.exit(get_command(config).entry_point())

--- a/src/gallia/command/base.py
+++ b/src/gallia/command/base.py
@@ -115,6 +115,7 @@ class BaseCommandConfig(GalliaBaseModel, cli_group="generic", config_section="ga
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     verbose: int = Field(0, description="increase verbosity on the console", short="v")
+    progress: bool = Field(True, description="Show a progress bar at the bottom of the terminal")
     trace_log: bool = Field(False, description="set the loglevel of the logfile to TRACE")
     pre_hook: str | None = Field(
         None,

--- a/src/gallia/command/base.py
+++ b/src/gallia/command/base.py
@@ -115,9 +115,6 @@ class BaseCommandConfig(GalliaBaseModel, cli_group="generic", config_section="ga
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     verbose: int = Field(0, description="increase verbosity on the console", short="v")
-    volatile_info: bool = Field(
-        True, description="Overwrite log lines with level info or lower in terminal output"
-    )
     trace_log: bool = Field(False, description="set the loglevel of the logfile to TRACE")
     pre_hook: str | None = Field(
         None,

--- a/src/gallia/progress.py
+++ b/src/gallia/progress.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: AISEC Pentesting Team
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Adopted from: https://mdk.fr/blog/how-apt-does-its-fancy-progress-bar.html
+
+import functools
+import shutil
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+
+eprint = functools.partial(print, end="", flush=True)
+
+
+def save_cursor_position() -> None:
+    eprint("\0337")
+
+
+def restore_cursor_position() -> None:
+    eprint("\0338")
+
+
+def lock_footer() -> None:
+    _, lines = shutil.get_terminal_size()
+    eprint(f"\033[0;{lines-1}r")
+
+
+def unlock_footer() -> None:
+    _, lines = shutil.get_terminal_size()
+    eprint(f"\033[0;{lines}r")
+
+
+def move_to_footer() -> None:
+    _, lines = shutil.get_terminal_size()
+    eprint(f"\033[{lines};0f")
+
+
+def move_cursor_up() -> None:
+    eprint("\033[1A")
+
+
+def erase_line() -> None:
+    eprint("\033[2K")
+
+
+def footer_init() -> None:
+    # Ensure the last line is available.
+    eprint("\n")
+    save_cursor_position()
+    lock_footer()
+    restore_cursor_position()
+    move_cursor_up()
+
+
+def footer_deinit() -> None:
+    save_cursor_position()
+    unlock_footer()
+    move_to_footer()
+    erase_line()
+    restore_cursor_position()
+
+
+type ProgressSetter = Callable[[int, int, str], None]
+
+
+@contextmanager
+def progress_bar(bar_len: int = 30) -> Iterator[ProgressSetter]:
+    def set_progress(count: int, total: int, suffix: str = "") -> None:
+        cols, _ = shutil.get_terminal_size()
+        filled_len = int(round(bar_len * count / float(total)))
+
+        percents = round(100.0 * count / float(total), 1)
+        bar = "█" * filled_len + "░" * (bar_len - filled_len)
+
+        content = f"{bar}  {percents}%  {suffix}"
+        if len(content) > cols:
+            content = content[: cols - 1] + "…"
+
+        save_cursor_position()
+        move_to_footer()
+        erase_line()
+        eprint(content)
+        restore_cursor_position()
+
+    footer_init()
+    try:
+        yield set_progress
+    finally:
+        footer_deinit()

--- a/tests/bats/helpers.bash
+++ b/tests/bats/helpers.bash
@@ -13,7 +13,6 @@ common_setup() {
 setup_gallia_toml() {
 	{
 		echo "[gallia]"
-		echo "no-volatile-info = true"
 		echo "verbosity = 1"
 
 		echo "[gallia.scanner]"

--- a/tests/bats/run_bats.sh
+++ b/tests/bats/run_bats.sh
@@ -7,7 +7,6 @@
 set -eu
 
 gallia script vecu rng "unix-lines:///tmp/vecu.sock" \
-	--no-volatile-info \
 	--seed 3 \
 	--mandatory-sessions 1 2 3 \
 	--mandatory-services DiagnosticSessionControl EcuReset ReadDataByIdentifier WriteDataByIdentifier RoutineControl SecurityAccess ReadMemoryByAddress WriteMemoryByAddress RequestDownload RequestUpload TesterPresent ReadDTCInformation ClearDiagnosticInformation InputOutputControlByIdentifier 2>vecu.log &


### PR DESCRIPTION
Remove the workaround `--volatile-info` and create a progress bar, which is inspired by `apt install`. The progress bar is only UI and only visible in the terminal, thus is not logged.

https://github.com/user-attachments/assets/b97a8b2c-ed90-432b-9392-7135277431ce




