### PR TITLE
chore: Introduce pip support and make uv optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,38 +16,38 @@ default:
 
 .PHONY: lint
 lint:
-	uv run mypy --pretty src tests
-	uv run ruff check src tests
-	uv run ruff format --check src tests
+	mypy --pretty src tests
+	ruff check src tests
+	ruff format --check src tests
 	find tests/bats \( -iname "*.bash" -or -iname "*.bats" -or -iname "*.sh" \) | xargs shellcheck
-	uv run reuse lint
+	reuse lint
 
 .PHONY: lint-win32
 lint-win32:
-	uv run mypy --platform win32 --exclude "gallia\/log\.py" --exclude "hr" src tests
-	uv run ruff check src tests
+	mypy --platform win32 --exclude "gallia\/log\.py" --exclude "hr" src tests
+	ruff check src tests
 
 .PHONY: fmt
 fmt:
-	uv run ruff check --fix-only src tests/pytest
-	uv run ruff format src tests/pytest
+	ruff check --fix-only src tests/pytest
+	ruff format src tests/pytest
 	find tests/bats \( -iname "*.bash" -or -iname "*.bats" -or -iname "*.sh" \) | xargs shfmt -w
 
 .PHONY: docs
 docs:
-	uv run $(MAKE) -C docs html
+	$(MAKE) -C docs html
 
 .PHONY: tests
 tests: pytest bats
 
 .PHONY: pytest
 pytest:
-	uv run python -m pytest -v --cov=$(PWD) --cov-report html tests/pytest
+	python -m pytest -v --cov=$(PWD) --cov-report html tests/pytest
 
 .PHONY: bats
 bats:
-	uv run ./tests/bats/run_bats.sh
+	./tests/bats/run_bats.sh
 
 .PHONY: clean
 clean:
-	uv run $(MAKE) -C docs clean
+	$(MAKE) -C docs clean

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ name = "gallia"
 version = "1.9.0"
 description = "Extendable Pentesting Framework"
 readme = "README.md"
+authors = [{name = "AISEC Pentesting Team"}]
 maintainers = [
     { name = "Stefan Tatschner", email = "stefan.tatschner@aisec.fraunhofer.de" },
     { name = "Tobias Specht", email = "tobias.specht@aisec.fraunhofer.de" },
@@ -48,7 +49,8 @@ dependencies = [
 "cursed-hr" = "gallia.cli.cursed_hr:main"
 "hr" = "gallia.cli.hr:main"
 
-[dependency-groups]
+# TODO: Change to dependency-groups once https://github.com/pypa/pip/issues/12963 is resolved
+[project.optional-dependencies]
 dev = [
     "Sphinx >=8.0",
     "construct-typing >=0.5.2,<0.7.0",

--- a/uv.lock
+++ b/uv.lock
@@ -287,7 +287,7 @@ dependencies = [
     { name = "zstandard" },
 ]
 
-[package.dev-dependencies]
+[package.optional-dependencies]
 dev = [
     { name = "construct-typing" },
     { name = "mypy" },
@@ -313,29 +313,25 @@ requires-dist = [
     { name = "argcomplete", specifier = ">=2,<4" },
     { name = "boltons", specifier = ">=24.1.0" },
     { name = "construct", specifier = ">=2.10,<3.0" },
+    { name = "construct-typing", marker = "extra == 'dev'", specifier = ">=0.5.2,<0.7.0" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0,<2.0" },
+    { name = "myst-parser", marker = "extra == 'dev'", specifier = ">=3.0.1,<4.1" },
     { name = "platformdirs", specifier = ">=2.6,<5.0" },
     { name = "pydantic", specifier = ">=2.0,<3.0" },
+    { name = "pylsp-mypy", marker = "extra == 'dev'", specifier = ">=0.6,<0.7" },
+    { name = "pylsp-rope", marker = "extra == 'dev'", specifier = ">=0.1,<0.2" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.1,<9.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.20,<0.25" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4,<6" },
+    { name = "python-lsp-server", marker = "extra == 'dev'", specifier = ">=1.5,<2.0" },
+    { name = "reuse", marker = "extra == 'dev'", specifier = ">=4.0,<5.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
+    { name = "sphinx", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "sphinx-rtd-theme", marker = "extra == 'dev'", specifier = ">=3" },
     { name = "tabulate", specifier = ">=0.9" },
+    { name = "types-aiofiles", marker = "extra == 'dev'", specifier = ">=23.1,<25.0" },
+    { name = "types-tabulate", marker = "extra == 'dev'", specifier = ">=0.9,<0.10" },
     { name = "zstandard", specifier = ">=0.19" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "construct-typing", specifier = ">=0.5.2,<0.7.0" },
-    { name = "mypy", specifier = ">=1.0,<2.0" },
-    { name = "myst-parser", specifier = ">=3.0.1,<4.1" },
-    { name = "pylsp-mypy", specifier = ">=0.6,<0.7" },
-    { name = "pylsp-rope", specifier = ">=0.1,<0.2" },
-    { name = "pytest", specifier = ">=7.1,<9.0" },
-    { name = "pytest-asyncio", specifier = ">=0.20,<0.25" },
-    { name = "pytest-cov", specifier = ">=4,<6" },
-    { name = "python-lsp-server", specifier = ">=1.5,<2.0" },
-    { name = "reuse", specifier = ">=4.0,<5.0" },
-    { name = "ruff", specifier = ">=0.8.0" },
-    { name = "sphinx", specifier = ">=8.0" },
-    { name = "sphinx-rtd-theme", specifier = ">=3" },
-    { name = "types-aiofiles", specifier = ">=23.1,<25.0" },
-    { name = "types-tabulate", specifier = ">=0.9,<0.10" },
 ]
 
 [[package]]


### PR DESCRIPTION
The current implementation of the pyproject.toml does not allow to install all requirements for dev environments to be installed with pip. While PEP 735 is accepted since almost two months, pip does not support it yet.

Instead, we rely on PEP 621 and by using optional-dependencies we can for now support pip by allowing to install the dev dependencies by specifying extras, such as

pip install .[dev]

This can be reverted once https://github.com/pypa/pip/issues/12963 is resolved.