### PR TITLE
chore: Let ruff run on the entire folder except docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ default:
 .PHONY: lint
 lint:
 	mypy --pretty src tests
-	ruff check src tests
-	ruff format --check src tests
+	ruff check
+	ruff format --check
 	find tests/bats \( -iname "*.bash" -or -iname "*.bats" -or -iname "*.sh" \) | xargs shellcheck
 	reuse lint
 
@@ -29,8 +29,8 @@ lint-win32:
 
 .PHONY: fmt
 fmt:
-	ruff check --fix-only src tests/pytest
-	ruff format src tests/pytest
+	ruff check --fix-only
+	ruff format
 	find tests/bats \( -iname "*.bash" -or -iname "*.bats" -or -iname "*.sh" \) | xargs shfmt -w
 
 .PHONY: docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ plugins = [
 [tool.ruff]
 target-version = "py312"
 line-length = 100
+exclude = ["docs/"]
 
 [tool.ruff.lint]
 select = [


### PR DESCRIPTION
Due to ruff's way of automatically loading more specific config files, this is actually the saner way of treating it.