### PR TITLE
Fix logging for multiple scanners in a script

### DIFF
--- a/src/gallia/cli/gallia.py
+++ b/src/gallia/cli/gallia.py
@@ -25,9 +25,8 @@ from gallia.log import Loglevel, setup_logging
 from gallia.plugins.plugin import CommandTree, load_commands, load_plugins
 from gallia.pydantic_argparse import ArgumentParser
 from gallia.pydantic_argparse import BaseCommand as PydanticBaseCommand
-from gallia.utils import get_log_level
 
-setup_logging(Loglevel.DEBUG)
+setup_logging("gallia", Loglevel.DEBUG)
 
 
 defaults = dict[type, dict[str, Any]]
@@ -123,7 +122,6 @@ def get_command(config: BaseCommandConfig) -> BaseCommand:
 def parse_and_run(
     commands: type[BaseCommand] | MutableMapping[str, CommandTree | type[BaseCommand]],
     auto_complete: bool = True,
-    setup_log: bool = True,
     top_level_options: Mapping[str, Callable[[], None]] | None = None,
     show_help_on_zero_args: bool = True,
 ) -> Never:
@@ -136,7 +134,6 @@ def parse_and_run(
 
     :param commands: A hierarchy of commands.
     :param auto_complete: Turns auto-complete functionality on.
-    :param setup_log: Setup logging according to the parameters in the parsed config.
     :param top_level_options: Optional top-level actions, such as "--version", given by a mapping of arguments and
                               functions. The program redirects control to the given function, once the program is
                               called with the corresponding argument and terminates after it returns.
@@ -181,12 +178,6 @@ def parse_and_run(
     _, config = parser.parse_typed_args()
 
     assert isinstance(config, BaseCommandConfig)
-
-    if setup_log:
-        setup_logging(
-            level=get_log_level(config.verbose),
-            no_volatile_info=not config.volatile_info,
-        )
 
     sys.exit(get_command(config).entry_point())
 

--- a/src/gallia/command/base.py
+++ b/src/gallia/command/base.py
@@ -334,6 +334,7 @@ class BaseCommand(FlockMixin, ABC):
                 logger_name="gallia",
                 stderr_level=stderr_level,
                 close_on_exit=False,
+                volatile_info=self.config.volatile_info,
             )
             if self.HAS_ARTIFACTS_DIR:
                 logging_handler.add_zst_file_handler(

--- a/src/gallia/log.py
+++ b/src/gallia/log.py
@@ -242,6 +242,7 @@ class PenlogPriority(IntEnum):
 class LoggingSetupHandler:
     def __init__(self) -> None:
         self.listeners: list[QueueListener] = []
+        self.handlers: list[logging.Handler] = []
 
     def __enter__(self) -> Self:
         return self
@@ -311,10 +312,14 @@ class LoggingSetupHandler:
         )
         queue_listener.start()
         self.listeners.append(queue_listener)
+        self.handlers.append(handler)
 
     def stop_logging(self) -> None:
         for listener in self.listeners:
             listener.stop()
+
+        for handler in self.handlers:
+            handler.close()
 
 
 def get_log_level(verbose: int) -> Loglevel:

--- a/src/gallia/utils.py
+++ b/src/gallia/utils.py
@@ -23,7 +23,7 @@ import aiofiles
 import pydantic
 from pydantic.networks import IPvAnyAddress
 
-from gallia.log import Loglevel, get_logger
+from gallia.log import get_logger
 
 if TYPE_CHECKING:
     from gallia.db.handler import DBHandler
@@ -259,27 +259,6 @@ def dump_args(args: Any) -> dict[str, str | int | float]:
                 settings[key] = value
 
     return settings
-
-
-def get_log_level(args: Any) -> Loglevel:
-    level = Loglevel.INFO
-    if hasattr(args, "verbose"):
-        if args.verbose == 1:
-            level = Loglevel.DEBUG
-        elif args.verbose >= 2:
-            level = Loglevel.TRACE
-    return level
-
-
-def get_file_log_level(args: Any) -> Loglevel:
-    level = Loglevel.DEBUG
-    if hasattr(args, "trace_log"):
-        if args.trace_log:
-            level = Loglevel.TRACE
-    elif hasattr(args, "verbose"):
-        if args.verbose >= 2:
-            level = Loglevel.TRACE
-    return level
 
 
 CONTEXT_SHARED_VARIABLE = "logger_name"

--- a/tests/pytest/test_helpers.py
+++ b/tests/pytest/test_helpers.py
@@ -11,7 +11,7 @@ from gallia.services.uds.core.utils import (
 )
 from gallia.utils import split_host_port
 
-setup_logging()
+setup_logging("gallia")
 
 
 def test_split_host_port_v4() -> None:

--- a/tests/pytest/test_transports.py
+++ b/tests/pytest/test_transports.py
@@ -15,7 +15,7 @@ listen_target = TargetURI("tcp://127.0.0.1:1234")
 test_data = [b"hello" b"tcp"]
 
 
-setup_logging()
+setup_logging("gallia")
 
 
 class TCPServer:


### PR DESCRIPTION
``` python
import gallia
import gallia.log
import gallia.command

logger = gallia.log.get_logger("gallia")

class Scanner1(gallia.command.Script):
    def main(self) -> None:
        logger.info(f"hi {self.__class__.__name__}")
        logger.error("error")
        logger.warning("warning")
        logger.notice("notice")
        logger.info("info")
        logger.debug("debug")
        logger.trace("trace")

class Scanner2(gallia.command.Script):
    def main(self) -> None:
        logger.info(f"hi {self.__class__.__name__}")


if __name__ == "__main__":
    # Each scanner sets up its own logging setup
    # with a logger called `gallia`. Logging setup
    # via the config class, in this case all default.
    Scanner1().entry_point()
    Scanner2().entry_point()

    # Alternatively, a context manager can be used
    # for more fine grained control.
    with gallia.log.setup_logging(
        logger_name="gallia",
        stderr_level=gallia.log.Loglevel.DEBUG,
        logfile="test.log.zst",
    ) as h:
        Scanner1(logging_handler=h).entry_point()
        Scanner2(logging_handler=h).entry_point()
```