### PR TITLE
chore: Remove from __future__ import annotations

### DIFF
--- a/justfile
+++ b/justfile
@@ -37,6 +37,18 @@ fmt:
 
 run-tests: run-test-pytest run-test-bats
 
+run-test-matrix:
+    #!/usr/bin/env bash
+
+    set -eu
+
+    matrix=("3.11" "3.12" "3.13")
+    for version in "${matrix[@]}"; do
+        echo "running tests with python version: $version"
+        uv sync --all-extras -p "$version"
+        uv run -p "$version" just run-tests
+    done
+
 run-test-pytest:
     python -m pytest -v --cov={{justfile_directory()}} --cov-report html tests/pytest
 

--- a/src/gallia/cli/cursed_hr.py
+++ b/src/gallia/cli/cursed_hr.py
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
-
 import curses
 import curses.ascii
 import gzip

--- a/src/gallia/cli/cursed_hr.py
+++ b/src/gallia/cli/cursed_hr.py
@@ -19,7 +19,7 @@ from datetime import datetime
 from enum import IntEnum, unique
 from math import ceil
 from pathlib import Path
-from typing import Any, BinaryIO
+from typing import TYPE_CHECKING, Any, BinaryIO
 
 import platformdirs
 import zstandard as zstd
@@ -86,6 +86,14 @@ class PriorityZone:
     priority: PenlogPriority
 
 
+# NOTE: Workaround for compatibility with Python 3.11 and older, see:
+# https://github.com/python/mypy/issues/13942
+if TYPE_CHECKING:
+    IntArray = array[int]
+else:
+    IntArray = array
+
+
 class EntryCache:
     """
     A simple two level cache that stores the latest accessed penlog entries.
@@ -97,7 +105,7 @@ class EntryCache:
     def __init__(
         self,
         file: BinaryIO | mmap.mmap,
-        entry_positions: array[int],
+        entry_positions: IntArray,
         cache_size: int = 20_000,
     ):
         self.file = file

--- a/src/gallia/log.py
+++ b/src/gallia/log.py
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
-
 import atexit
 import dataclasses
 import datetime
@@ -25,13 +23,9 @@ from logging.handlers import QueueHandler, QueueListener
 from pathlib import Path
 from queue import Queue
 from types import TracebackType
-from typing import TYPE_CHECKING, Any, BinaryIO, Self, TextIO, TypeAlias, cast
+from typing import Any, BinaryIO, Self, TextIO, TypeAlias, cast
 
 import zstandard
-
-if TYPE_CHECKING:
-    from logging import _ExcInfoType
-
 
 gmt_offset = time.localtime().tm_gmtoff
 tz = datetime.timezone(datetime.timedelta(seconds=gmt_offset))
@@ -153,7 +147,7 @@ class PenlogPriority(IntEnum):
     TRACE = 8
 
     @classmethod
-    def from_str(cls, string: str) -> PenlogPriority:
+    def from_str(cls, string: str) -> "PenlogPriority":
         """Converts a string to an instance of PenlogPriority.
         ``string`` can be a numeric value (0 to 8 inclusive)
         or a string with a case insensitive name of the level
@@ -185,7 +179,7 @@ class PenlogPriority(IntEnum):
                 raise ValueError(f"{string} not a valid priority")
 
     @classmethod
-    def from_level(cls, value: int) -> PenlogPriority:
+    def from_level(cls, value: int) -> "PenlogPriority":
         """Converts an int value (e.g. from python's logging module)
         to an instance of this class.
         """
@@ -765,7 +759,7 @@ class Logger(logging.Logger):
         self,
         msg: Any,
         *args: Any,
-        exc_info: _ExcInfoType = None,
+        exc_info: Any = None,
         stack_info: bool = False,
         extra: dict[str, Any] | None = None,
         **kwargs: Any,
@@ -785,7 +779,7 @@ class Logger(logging.Logger):
         self,
         msg: Any,
         *args: Any,
-        exc_info: _ExcInfoType = None,
+        exc_info: Any = None,
         stack_info: bool = False,
         extra: dict[str, Any] | None = None,
         **kwargs: Any,
@@ -805,7 +799,7 @@ class Logger(logging.Logger):
         self,
         msg: Any,
         *args: Any,
-        exc_info: _ExcInfoType = None,
+        exc_info: Any = None,
         stack_info: bool = False,
         extra: dict[str, Any] | None = None,
         **kwargs: Any,

--- a/src/gallia/services/uds/core/client.py
+++ b/src/gallia/services/uds/core/client.py
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
-
 import asyncio
 import struct
 from collections.abc import Sequence

--- a/src/gallia/services/uds/core/exception.py
+++ b/src/gallia/services/uds/core/exception.py
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
-
 import asyncio
 from abc import ABC
 from typing import Any
@@ -72,7 +70,7 @@ class UnexpectedResponse(ResponseException):
 
 class UnexpectedNegativeResponse(UnexpectedResponse, ABC):
     RESPONSE_CODE: UDSErrorCodes
-    _CONCRETE_EXCEPTIONS: dict[UDSErrorCodes | None, type[UnexpectedNegativeResponse]] = {}
+    _CONCRETE_EXCEPTIONS: dict[UDSErrorCodes | None, type["UnexpectedNegativeResponse"]] = {}
 
     def __init_subclass__(cls, /, response_code: UDSErrorCodes, **kwargs: Any) -> None:
         super().__init_subclass__(**kwargs)
@@ -93,7 +91,7 @@ class UnexpectedNegativeResponse(UnexpectedResponse, ABC):
     @staticmethod
     def parse_dynamic(
         request: UDSRequest, response: NegativeResponse, message: str | None = None
-    ) -> UnexpectedNegativeResponse:
+    ) -> "UnexpectedNegativeResponse":
         return UnexpectedNegativeResponse._CONCRETE_EXCEPTIONS[response.response_code](
             request, response, message
         )

--- a/src/gallia/services/uds/core/service.py
+++ b/src/gallia/services/uds/core/service.py
@@ -1640,7 +1640,7 @@ class DefineByIdentifierRequest(
         return pdu
 
     @classmethod
-    def _from_pdu(cls, pdu: bytes) -> DefineByIdentifierRequest:
+    def _from_pdu(cls, pdu: bytes) -> Self:
         dynamically_defined_data_identifier = from_bytes(pdu[2:4])
         source_data_identifiers: list[int] = []
         positions_in_source_data_record: list[int] = []
@@ -1654,7 +1654,7 @@ class DefineByIdentifierRequest(
             positions_in_source_data_record.append(pdu[i + 2])
             memory_sizes.append(pdu[i + 3])
 
-        return DefineByIdentifierRequest(
+        return cls(
             dynamically_defined_data_identifier,
             source_data_identifiers,
             positions_in_source_data_record,
@@ -1783,7 +1783,7 @@ class DefineByMemoryAddressRequest(
         return pdu
 
     @classmethod
-    def _from_pdu(cls, pdu: bytes) -> DefineByMemoryAddressRequest:
+    def _from_pdu(cls, pdu: bytes) -> Self:
         dynamically_defined_data_identifier = from_bytes(pdu[2:4])
         address_and_length_format_identifier = pdu[4]
         address_length, size_length = address_and_size_length(address_and_length_format_identifier)
@@ -1799,7 +1799,7 @@ class DefineByMemoryAddressRequest(
                 from_bytes(pdu[i + address_length : i + address_length + size_length])
             )
 
-        return DefineByMemoryAddressRequest(
+        return cls(
             dynamically_defined_data_identifier,
             memory_addresses,
             memory_sizes,
@@ -1856,7 +1856,7 @@ class ClearDynamicallyDefinedDataIdentifierRequest(
             )
 
     @classmethod
-    def _from_pdu(cls, pdu: bytes) -> ClearDynamicallyDefinedDataIdentifierRequest:
+    def _from_pdu(cls, pdu: bytes) -> Self:
         dynamically_defined_data_identifier: int | None = None
 
         if len(pdu) > 2:

--- a/src/gallia/services/uds/ecu.py
+++ b/src/gallia/services/uds/ecu.py
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
-
 import asyncio
 from asyncio import Task
 from datetime import UTC, datetime

--- a/src/gallia/transports/doip.py
+++ b/src/gallia/transports/doip.py
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
-
 import asyncio
 import socket
 import struct
@@ -40,7 +38,7 @@ class RoutingActivationRequestTypes(IntEnum):
     CentralSecurity = 0xE0
 
     @classmethod
-    def _missing_(cls, value: Any) -> RoutingActivationRequestTypes:
+    def _missing_(cls, value: Any) -> "RoutingActivationRequestTypes":
         if value in range(0xE1, 0x100):
             return cls.ManufacturerSpecific
         return cls.RESERVED
@@ -62,7 +60,7 @@ class RoutingActivationResponseCodes(IntEnum):
     SuccessConfirmationRequired = 0x11
 
     @classmethod
-    def _missing_(cls, value: Any) -> RoutingActivationResponseCodes:
+    def _missing_(cls, value: Any) -> "RoutingActivationResponseCodes":
         if value in range(0xE0, 0xFF):
             return cls.ManufacturerSpecific
         return cls.RESERVED
@@ -113,7 +111,7 @@ class DiagnosticMessageNegativeAckCodes(IntEnum):
     TransportProtocolError = 0x08
 
     @classmethod
-    def _missing_(cls, value: Any) -> DiagnosticMessageNegativeAckCodes:
+    def _missing_(cls, value: Any) -> "DiagnosticMessageNegativeAckCodes":
         return cls.RESERVED
 
 
@@ -135,7 +133,7 @@ class GenericDoIPHeaderNACKCodes(IntEnum):
     InvalidPayloadLength = 0x04
 
     @classmethod
-    def _missing_(cls, value: Any) -> GenericDoIPHeaderNACKCodes:
+    def _missing_(cls, value: Any) -> "GenericDoIPHeaderNACKCodes":
         return cls.RESERVED
 
 
@@ -178,7 +176,7 @@ class GenericHeader:
         )
 
     @classmethod
-    def unpack(cls, data: bytes) -> GenericHeader:
+    def unpack(cls, data: bytes) -> Self:
         (
             protocol_version,
             inverse_protocol_version,
@@ -205,7 +203,7 @@ class GenericDoIPHeaderNACK:
         )
 
     @classmethod
-    def unpack(cls, data: bytes) -> GenericDoIPHeaderNACK:
+    def unpack(cls, data: bytes) -> Self:
         (generic_header_NACK_code,) = struct.unpack("!B", data)
         return cls(
             GenericDoIPHeaderNACKCodes(generic_header_NACK_code),
@@ -218,6 +216,31 @@ class VehicleIdentificationRequestMessage:
         return b""
 
 
+@unique
+class FurtherActionCodes(IntEnum):
+    RESERVED = 0x0F
+    ManufacturerSpecific = 0xFF
+    NoFurtherActionRequired = 0x00
+    RoutingActivationRequiredToInitiateCentralSecurity = 0x10
+
+    @classmethod
+    def _missing_(cls, value: Any) -> "FurtherActionCodes":
+        if value in range(0x11, 0x100):
+            return cls.ManufacturerSpecific
+        return cls.RESERVED
+
+
+@unique
+class SynchronisationStatusCodes(IntEnum):
+    RESERVED = 0xFF
+    VINGIDSynchronized = 0x00
+    IncompleteVINGIDNotSynchronized = 0x10
+
+    @classmethod
+    def _missing_(cls, value: Any) -> "SynchronisationStatusCodes":
+        return cls.RESERVED
+
+
 @dataclass
 class VehicleAnnouncementMessage:
     VIN: bytes
@@ -228,7 +251,7 @@ class VehicleAnnouncementMessage:
     VINGIDSyncStatus: SynchronisationStatusCodes | None
 
     @classmethod
-    def unpack(cls, data: bytes) -> VehicleAnnouncementMessage:
+    def unpack(cls, data: bytes) -> Self:
         if len(data) == 32:
             # VINGIDSyncStatus is optional
             (vin, logical_address, eid, gid, further_action_required) = struct.unpack(
@@ -257,35 +280,21 @@ class VehicleAnnouncementMessage:
         )
 
 
-@unique
-class FurtherActionCodes(IntEnum):
-    RESERVED = 0x0F
-    ManufacturerSpecific = 0xFF
-    NoFurtherActionRequired = 0x00
-    RoutingActivationRequiredToInitiateCentralSecurity = 0x10
-
-    @classmethod
-    def _missing_(cls, value: Any) -> FurtherActionCodes:
-        if value in range(0x11, 0x100):
-            return cls.ManufacturerSpecific
-        return cls.RESERVED
-
-
-@unique
-class SynchronisationStatusCodes(IntEnum):
-    RESERVED = 0xFF
-    VINGIDSynchronized = 0x00
-    IncompleteVINGIDNotSynchronized = 0x10
-
-    @classmethod
-    def _missing_(cls, value: Any) -> SynchronisationStatusCodes:
-        return cls.RESERVED
-
-
 @dataclass
 class DoIPEntityStatusRequest:
     def pack(self) -> bytes:
         return b""
+
+
+@unique
+class NodeTypes(IntEnum):
+    RESERVED = 0xFF
+    Gateway = 0x00
+    Node = 0x01
+
+    @classmethod
+    def _missing_(cls, value: Any) -> "NodeTypes":
+        return cls.RESERVED
 
 
 @dataclass
@@ -296,7 +305,7 @@ class DoIPEntityStatusResponse:
     MaximumDataSize: int | None
 
     @classmethod
-    def unpack(cls, data: bytes) -> DoIPEntityStatusResponse:
+    def unpack(cls, data: bytes) -> Self:
         if len(data) == 3:
             # MaximumDataSize is optional
             (nt, mcts, ncts) = struct.unpack("!BBB", data)
@@ -305,17 +314,6 @@ class DoIPEntityStatusResponse:
             (nt, mcts, ncts, mds) = struct.unpack("!BBBI", data)
 
         return cls(NodeTypes(nt), mcts, ncts, mds)
-
-
-@unique
-class NodeTypes(IntEnum):
-    RESERVED = 0xFF
-    Gateway = 0x00
-    Node = 0x01
-
-    @classmethod
-    def _missing_(cls, value: Any) -> NodeTypes:
-        return cls.RESERVED
 
 
 @dataclass
@@ -338,7 +336,7 @@ class RoutingActivationResponse:
     # OEMReserved uint32
 
     @classmethod
-    def unpack(cls, data: bytes) -> RoutingActivationResponse:
+    def unpack(cls, data: bytes) -> Self:
         (
             source_address,
             target_address,
@@ -372,7 +370,7 @@ class DiagnosticMessage:
         )
 
     @classmethod
-    def unpack(cls, data: bytes) -> DiagnosticMessage:
+    def unpack(cls, data: bytes) -> Self:
         source_address, target_address = struct.unpack("!HH", data[:4])
         data = data[4:]
         return cls(source_address, target_address, data)
@@ -401,7 +399,7 @@ class DiagnosticMessagePositiveAcknowledgement(DiagnosticMessageAcknowledgement)
     ACKCode: DiagnosticMessagePositiveAckCodes
 
     @classmethod
-    def unpack(cls, data: bytes) -> DiagnosticMessagePositiveAcknowledgement:
+    def unpack(cls, data: bytes) -> Self:
         source_address, target_address, ack_code = struct.unpack("!HHB", data[:5])
         prev_data = data[5:]
 
@@ -417,7 +415,7 @@ class DiagnosticMessageNegativeAcknowledgement(DiagnosticMessageAcknowledgement)
     ACKCode: DiagnosticMessageNegativeAckCodes
 
     @classmethod
-    def unpack(cls, data: bytes) -> DiagnosticMessageNegativeAcknowledgement:
+    def unpack(cls, data: bytes) -> Self:
         source_address, target_address, ack_code = struct.unpack("!HHB", data[:5])
         prev_data = data[5:]
 

--- a/src/gallia/transports/hsfz.py
+++ b/src/gallia/transports/hsfz.py
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
-
 import asyncio
 import errno
 import struct
@@ -38,7 +36,7 @@ class HSFZStatus(IntEnum):
     OutOfMemory = 0xFF
 
     @classmethod
-    def _missing_(cls, value: Any) -> HSFZStatus:
+    def _missing_(cls, value: Any) -> "HSFZStatus":
         return cls.UNDEFINED
 
 
@@ -65,7 +63,7 @@ class HSFZDiagReqHeader:
         return struct.pack("!BB", self.src_addr, self.dst_addr)
 
     @classmethod
-    def unpack(cls, data: bytes) -> HSFZDiagReqHeader:
+    def unpack(cls, data: bytes) -> Self:
         src_addr, dst_addr = struct.unpack("!BB", data)
         return cls(src_addr, dst_addr)
 
@@ -105,7 +103,7 @@ class HSFZConnection:
         src_addr: int,
         dst_addr: int,
         ack_timeout: float,
-    ) -> HSFZConnection:
+    ) -> Self:
         reader, writer = await asyncio.open_connection(host, port)
         return cls(
             reader,
@@ -332,7 +330,7 @@ class HSFZTransport(BaseTransport, scheme="hsfz"):
         cls,
         target: str | TargetURI,
         timeout: float | None = None,
-    ) -> HSFZTransport:
+    ) -> Self:
         t = TargetURI(target) if isinstance(target, str) else target
         if t.hostname is None:
             raise ValueError("no hostname specified")

--- a/src/gallia/transports/tcp.py
+++ b/src/gallia/transports/tcp.py
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
-
 import asyncio
 from typing import Self
 

--- a/src/gallia/utils.py
+++ b/src/gallia/utils.py
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
-
 import asyncio
 import contextvars
 import importlib.util
@@ -177,8 +175,8 @@ async def catch_and_log_exception(
 
 async def write_target_list(
     path: Path,
-    targets: list[TargetURI],
-    db_handler: DBHandler | None = None,
+    targets: list["TargetURI"],
+    db_handler: "DBHandler | None" = None,
 ) -> None:
     """Write a list of ECU connection strings (urls) into file
 


### PR DESCRIPTION
This guy is deprecated:
https://docs.python.org/3.14/whatsnew/3.14.html#from-future-import-annotations

Remove it.
