### PR TITLE
fix(log): Always call self.close() on __exit__

### DIFF
--- a/src/gallia/log.py
+++ b/src/gallia/log.py
@@ -660,8 +660,7 @@ class PenlogReader:
         exc_value: BaseException | None,
         tb: TracebackType | None,
     ) -> None:
-        if exc_type is not None:
-            self.close()
+        self.close()
 
 
 @unique


### PR DESCRIPTION
Tbh I do not see a reason why the if clause is here in the first place?