### PR TITLE
fix(discover-doip): Fix incorrect variable in log message

### DIFF
--- a/src/gallia/commands/discover/doip.py
+++ b/src/gallia/commands/discover/doip.py
@@ -497,7 +497,7 @@ class DoIPDiscoverer(AsyncScript):
                 while True:
                     data, from_addr = await asyncio.wait_for(loop.sock_recvfrom(sock, 1024), 2)
                     info = VehicleAnnouncementMessage.unpack(data[8:])
-                    logger.notice(f"[💝]: {addr} responded: {info}")
+                    logger.notice(f"[💝]: {from_addr} responded: {info}")
                     found.append(from_addr)
             except TimeoutError:
                 logger.info("[💔] Reached timeout...")


### PR DESCRIPTION
004a764c3f6add4d2dfb2db5b25baf9ff57f35c2 did not take sufficient care to adapt existing code to the new changes.