### PR TITLE
fix(client): Do no longer send TesterPresent in ResponsePending loop

### DIFF
--- a/src/gallia/services/uds/core/client.py
+++ b/src/gallia/services/uds/core/client.py
@@ -134,10 +134,6 @@ class UDSClient:
                         raise BrokenPipeError("connection to target lost")
                     logger.debug(raw_resp.hex(), extra={"tags": ["read", "uds"] + tags})
                 except TimeoutError as e:
-                    # Send a tester present to indicate that
-                    # we are still there.
-                    # TODO: Is this really necessary?
-                    await self._tester_present(suppress_resp=True)
                     n_timeout += 1
                     if n_timeout >= max_n_timeout:
                         last_exception = MissingResponse(request, str(e))


### PR DESCRIPTION
We now had multiple occasions where the TesterPresent request with suppress response bit set triggered a reply by the ECU. This reply will be treated as the awaited answer of the ResponsePending loop which cannot be recovered from.

Not sending TesterPresent in the loop also conforms to the UDS standard.