### PR TITLE
fix(db): Create single task that executes DiagnosticMessage queries

### DIFF
--- a/src/gallia/commands/discover/doip.py
+++ b/src/gallia/commands/discover/doip.py
@@ -73,7 +73,6 @@ class DoIPDiscoverer(AsyncScript):
         self.config: DoIPDiscovererConfig = config
 
     # This is an ugly hack to circumvent AsyncScript's shortcomings regarding return codes
-
     def run(self) -> int:
         return asyncio.run(self.main2())
 
@@ -90,7 +89,11 @@ class DoIPDiscoverer(AsyncScript):
 
         if self.db_handler is not None:
             try:
+                # We need to manually connect to the DB because we are an AsyncScript that
+                # does not do so automatically
+                await self.db_handler.connect()
                 await self.db_handler.insert_discovery_run("doip")
+                await self.db_handler.disconnect()
             except Exception as e:
                 logger.warning(f"Could not write the discovery run to the database: {e!r}")
 
@@ -420,7 +423,11 @@ class DoIPDiscoverer(AsyncScript):
                     with self.artifacts_dir.joinpath("4_responsive_targets.txt").open("a") as f:
                         f.write(f"{current_target}\n")
                     if self.db_handler is not None:
+                        # We need to manually connect to the DB because we are an AsyncScript that
+                        # does not do so automatically
+                        await self.db_handler.connect()
                         await self.db_handler.insert_discovery_result(current_target)
+                        await self.db_handler.disconnect()
 
                 if (
                     abs(source_address - conn.target_addr) > 10


### PR DESCRIPTION
This commit introduces an executor task that handles queries coming from a queue. Compared to the old approach that easily generated >100k tasks per scan, this approach is way more memory friendly.

What adds to this is that previously the tasks were generated in a different event loop than the one they were awaited in, leading to dangling objects that persisted until the python interpreter closed. This commit removes these memory leaks which becomes extremely important when scanners are used "as lib".