### PR TITLE
fix: Let wait_for_ecu() reconnect on all ConnectionErrors incl. hidden

### DIFF
--- a/src/gallia/services/uds/core/client.py
+++ b/src/gallia/services/uds/core/client.py
@@ -97,6 +97,9 @@ class UDSClient:
             except ConnectionError as e:
                 logger.warning(f"{request} failed with: {e!r}")
                 last_exception = MissingResponse(request, str(e))
+                # Explicitly set __cause__ such that higher levels might react, e.g. wait_for_ecu()
+                # Basically equal to "raise last_exception from e"
+                last_exception.__cause__ = e
                 if i < max_retry:
                     logger.info(f"Sleeping for {wait_time}s before attempting to reconnect")
                     await asyncio.sleep(wait_time)


### PR DESCRIPTION
Currently, a broken transport triggers a reconnect in request_unsafe(), but only in case of retries. Since wait_for_ecu specifically sets retries to 0 this is not happening and instead ConnectionErrors are transformed to UDSExceptions.
This commit brings two major changes:

1. `request_unsafe` sets the __cause__ of the MissingResponse to ConnectionError to provide callers with additional information
2. `wait_for_ecu` treats a MissingRespone caused by a ConnectionError the same as a ConnectionError and calls reconnect