### PR TITLE
fix: Serialize CAN frames when DLC is not set

### DIFF
--- a/src/gallia/transports/can.py
+++ b/src/gallia/transports/can.py
@@ -44,7 +44,7 @@ class CANMessage:
     arbitration_id: int = 0
 
     # TODO: Add a frametype attribute?
-    is_extended_id: bool = True
+    is_extended_id: bool = False
     is_remote_frame: bool = False
     is_error_frame: bool = False
 
@@ -55,6 +55,7 @@ class CANMessage:
     bitrate_switch: bool = False
     error_state_indicator: bool = False
 
+    # TODO: Is this semantically correct? Check this.
     def __len__(self) -> int:
         if self.dlc is None:
             return len(self.data)
@@ -79,7 +80,7 @@ class CANMessage:
             flags |= CANFD_ESI
         max_len = 64 if self.is_fd else 8
         data = bytes(self.data).ljust(max_len, b"\x00")
-        return CAN_HEADER_FMT.pack(can_id, self.dlc, flags) + data
+        return CAN_HEADER_FMT.pack(can_id, len(self), flags) + data
 
     @staticmethod
     def _dissect_can_frame(frame: bytes) -> tuple[int, int, int, bytes]:

--- a/tests/pytest/test_can_message.py
+++ b/tests/pytest/test_can_message.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: AISEC Pentesting Team
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+
+assert sys.platform.startswith("linux"), "unsupported platform"
+
+from gallia.transports.can import CANMessage
+
+
+def test_can_message_deserialization() -> None:
+    test_table = [
+        (
+            b"\x00\x07\x00\x00\x04\x00\x00\x00s\x02>\x00\x00\x00\x00\x00",
+            CANMessage(arbitration_id=0x700, dlc=4, data=bytes([0x73, 0x02, 0x3E, 0x00])),
+        ),
+    ]
+
+    for input_, output in test_table:
+        frame = CANMessage.unpack(input_)
+        assert frame == output


### PR DESCRIPTION
- **fix: Serialize CAN frame even if dlc is not set**
- **tests: Add tests for serializing CAN frames**
