### PR TITLE
!feat: Remove HAS_ARTIFACTS_DIR in favor of artifacts_base config

### DIFF
--- a/src/gallia/commands/discover/find_xcp.py
+++ b/src/gallia/commands/discover/find_xcp.py
@@ -48,8 +48,6 @@ class UdpFindXCPConfig(FindXCPConfig):
 class FindXCP(AsyncScript, ABC):
     """Find XCP Slave"""
 
-    HAS_ARTIFACTS_DIR = True
-
     def __init__(self, config: FindXCPConfig):
         super().__init__(config)
         self.config: FindXCPConfig = config

--- a/src/gallia/commands/discover/hsfz.py
+++ b/src/gallia/commands/discover/hsfz.py
@@ -16,7 +16,6 @@ from gallia.services.uds.core.service import (
 from gallia.services.uds.helpers import raise_for_mismatch
 from gallia.transports.base import TargetURI
 from gallia.transports.hsfz import HSFZConnection
-from gallia.utils import write_target_list
 
 logger = get_logger(__name__)
 
@@ -123,6 +122,15 @@ class HSFZDiscoverer(UDSDiscoveryScanner):
                 found.append(target)
 
         logger.result(f"Found {len(found)} targets")
-        ecus_file = self.artifacts_dir.joinpath("ECUs.txt")
-        logger.result(f"Writing urls to file: {ecus_file}")
-        await write_target_list(ecus_file, found, self.db_handler)
+
+        if self.artifacts_dir is not None:
+            ecus_file = self.artifacts_dir.joinpath("ECUs.txt")
+            logger.result(f"Writing urls to file: {ecus_file}")
+            with ecus_file.open("w") as f:
+                for target in found:
+                    f.write(f"{target}\n")
+
+        if self.db_handler is not None:
+            logger.result("Writing urls to database")
+            for target in found:
+                await self.db_handler.insert_discovery_result(str(target))

--- a/src/gallia/commands/scan/uds/sa_dump_seeds.py
+++ b/src/gallia/commands/scan/uds/sa_dump_seeds.py
@@ -143,7 +143,11 @@ class SASeedsDumper(UDSScanner):
             logger.critical(f"could not change to session: {resp}")
             return
 
-        seeds_file = self.artifacts_dir.joinpath("seeds.bin")
+        if self.artifacts_dir is None:
+            logger.warning("No artifacts base folder given, saving seeds to current working dir!")
+            seeds_file = Path.cwd().joinpath("seeds.bin")
+        else:
+            seeds_file = self.artifacts_dir.joinpath("seeds.bin")
         file = seeds_file.open("wb", buffering=0)
         duration = self.config.duration * 60
         start_time = time.time()

--- a/src/gallia/db/handler.py
+++ b/src/gallia/db/handler.py
@@ -255,7 +255,7 @@ class DBHandler:
         script: str,
         config: GalliaBaseModel,
         start_time: datetime,
-        path: Path,
+        path: Path | None,
     ) -> None:
         assert self.connection is not None, "Not connected to the database"
 
@@ -279,7 +279,9 @@ class DBHandler:
 
         await self.connection.commit()
 
-    async def complete_run_meta(self, end_time: datetime, exit_code: int, path: Path) -> None:
+    async def complete_run_meta(
+        self, end_time: datetime, exit_code: int, path: Path | None
+    ) -> None:
         assert self.connection is not None, "Not connected to the database"
         assert self.meta is not None, "Run meta not yet created"
 

--- a/src/gallia/utils.py
+++ b/src/gallia/utils.py
@@ -9,16 +9,10 @@ import re
 import sys
 from collections.abc import Awaitable, Callable
 from functools import wraps
-from pathlib import Path
 from types import ModuleType
-from typing import TYPE_CHECKING, Any, ParamSpec, TypeVar
+from typing import Any, ParamSpec, TypeVar
 
 from gallia.log import Loglevel, get_logger
-
-if TYPE_CHECKING:
-    from gallia.db.handler import DBHandler
-    from gallia.transports import TargetURI
-
 
 logger = get_logger(__name__)
 
@@ -170,26 +164,6 @@ async def catch_and_log_exception(
     except Exception as e:
         logger.error(f"func {func.__name__} failed: {repr(e)}")
         return None
-
-
-async def write_target_list(
-    path: Path,
-    targets: list["TargetURI"],
-    db_handler: "DBHandler | None" = None,
-) -> None:
-    """Write a list of ECU connection strings (urls) into file
-
-    :param path: output file
-    :param targets: list of ECUs with ECU specific url and params as dict
-    :params db_handler: if given, urls are also written to the database as discovery results
-    :return: None
-    """
-    with path.open("w") as f:
-        for target in targets:
-            f.write(f"{target}\n")
-
-            if db_handler is not None:
-                await db_handler.insert_discovery_result(str(target))
 
 
 def lazy_import(name: str) -> ModuleType:

--- a/tests/bats/helpers.bash
+++ b/tests/bats/helpers.bash
@@ -15,6 +15,7 @@ setup_gallia_toml() {
 		echo "[gallia]"
 		echo "no-volatile-info = true"
 		echo "verbosity = 1"
+		echo "artifacts_base = \"$BATS_TMPDIR/gallia\""
 
 		echo "[gallia.scanner]"
 		echo 'target = "unix-lines:///tmp/vecu.sock"'


### PR DESCRIPTION
Currently, the property `HAS_ARTIFACTS_DIR` of `BaseCommand` determines whether a folder is created and artifacts are saved.

This commit removes this property in favor of the config property `artifacts_base`, such that artifacts are automatically saved, once the property is filled in the config object.

These adaptions bring two major benefits:

1. If gallia is run quickly from the CLI, it does not clutter temporary storage or require dependencies such as dumpcap.
2. When calling individual scanners from within python with gallia as a lib, the interface to decide whether and where to artifacts are saved is more straightforward.