### PR TITLE
fix(doip-discover): Remove left-over double db_connect call

### DIFF
--- a/src/gallia/commands/discover/doip.py
+++ b/src/gallia/commands/discover/doip.py
@@ -82,11 +82,7 @@ class DoIPDiscoverer(AsyncScript):
 
         if self.db_handler is not None:
             try:
-                # We need to manually connect to the DB because we are an AsyncScript that
-                # does not do so automatically
-                await self.db_handler.connect()
                 await self.db_handler.insert_discovery_run("doip")
-                await self.db_handler.disconnect()
             except Exception as e:
                 logger.warning(f"Could not write the discovery run to the database: {e!r}")
 
@@ -425,11 +421,7 @@ class DoIPDiscoverer(AsyncScript):
                         with self.artifacts_dir.joinpath("4_responsive_targets.txt").open("a") as f:
                             f.write(f"{current_target}\n")
                     if self.db_handler is not None:
-                        # We need to manually connect to the DB because we are an AsyncScript that
-                        # does not do so automatically
-                        await self.db_handler.connect()
                         await self.db_handler.insert_discovery_result(current_target)
-                        await self.db_handler.disconnect()
 
                 if (
                     abs(source_address - conn.target_addr) > 10


### PR DESCRIPTION
Since 3542f3acecc71fb54cf225d14a17719531b45d25 the `db_handler` is part of BaseCommand and can thus directly be used by AsyncSripts.