### PR TITLE
fix(transport): Remove double transport reference for UDSScanner class

### DIFF
--- a/src/gallia/command/base.py
+++ b/src/gallia/command/base.py
@@ -473,8 +473,20 @@ class Scanner(AsyncScript, ABC):
         super().__init__(config)
         self.config: ScannerConfig = config
         self.power_supply: PowerSupply | None = None
-        self.transport: BaseTransport
+        self._transport: BaseTransport | None = None
         self.dumpcap: Dumpcap | None = None
+
+    @property
+    def transport(self) -> BaseTransport:
+        if self._transport is None:
+            raise RuntimeError("Transport accessed before first initialization!")
+        return self._transport
+
+    @transport.setter
+    def transport(self, transport: BaseTransport) -> None:
+        if not isinstance(transport, BaseTransport):
+            logger.critical(f"Attempting to assign wrong type to transport: {type(transport)}")
+        self._transport = transport
 
     @abstractmethod
     async def main(self) -> None: ...


### PR DESCRIPTION
When initializing a UDSScanner class, it sets up its own `ECU` object that re-uses `self.transport` and offers extended functionality.

It is bad practice to maintain two references two a `BaseTransport` object at two different places, thus make `self.transport` a link to `self.ecu.transport` as soon as the latter is initialized.