### PR TITLE
fix(base): Catch CancelledError additionally to KeyboardInterrupt

### DIFF
--- a/src/gallia/cli/gallia.py
+++ b/src/gallia/cli/gallia.py
@@ -6,7 +6,6 @@ import argparse
 import asyncio
 import json
 import os
-import signal
 import sys
 from collections.abc import Callable, Mapping, MutableMapping, Sequence
 from importlib.metadata import version as meta_version
@@ -311,20 +310,17 @@ def template() -> None:
 
 
 def main() -> None:
-    try:
-        gallia_commands = load_commands()
-        parse_and_run(
-            gallia_commands,
-            top_level_options={
-                "--version": (version, "show version and exit"),
-                "--show-plugins": (show_plugins, "show registered plugins"),
-                "--show-config": (show_config, "show loaded config"),
-                "--template": (template, "generate a annotated config template"),
-            },
-            show_help_on_zero_args=True,
-        )
-    except KeyboardInterrupt:
-        sys.exit(128 + signal.SIGINT)
+    gallia_commands = load_commands()
+    parse_and_run(
+        gallia_commands,
+        top_level_options={
+            "--version": (version, "show version and exit"),
+            "--show-plugins": (show_plugins, "show registered plugins"),
+            "--show-config": (show_config, "show loaded config"),
+            "--template": (template, "generate a annotated config template"),
+        },
+        show_help_on_zero_args=True,
+    )
 
 
 if __name__ == "__main__":

--- a/src/gallia/command/base.py
+++ b/src/gallia/command/base.py
@@ -330,7 +330,8 @@ class BaseCommand(FlockMixin, ABC):
         exit_code = 0
         try:
             exit_code = await self.run()
-        except KeyboardInterrupt:
+        except (KeyboardInterrupt, asyncio.CancelledError) as e:
+            logger.debug(f"{self.__class__} got interrupted: {e!r}")
             exit_code = 128 + signal.SIGINT
         # Ensure that META.json gets written in the case a
         # command calls sys.exit().


### PR DESCRIPTION
Since we've transitioned to full asyncio, there were no more KeyboardInterrupts in our code. Instead, asnycio catches it and raises CancelledErrors, which inherit from BaseException instead of Exception.

This commit effectively reverts 5a25254ddade463180de52fbf4d14fb34c7a7a93 and instead catches CancelledErrors in base.py.

Strictly speaking, CancelledErrors should be raised and propagated though...