### PR TITLE
chore: Use dependency-groups in pyproject.toml

### DIFF
--- a/justfile
+++ b/justfile
@@ -41,7 +41,7 @@ run-test-matrix:
     matrix=("3.11" "3.12" "3.13" "3.14")
     for version in "${matrix[@]}"; do
         echo "running tests with python version: $version"
-        uv sync --all-extras -p "$version"
+        uv sync -p "$version"
         uv run -p "$version" just run-tests
     done
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,8 +50,7 @@ dependencies = [
 "cursed-hr" = "gallia.cli.cursed_hr:main"
 "hr" = "gallia.cli.hr:main"
 
-# TODO: Change to dependency-groups once https://github.com/pypa/pip/issues/12963 is resolved
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
     "Sphinx >=8.0",
     "construct-typing >=0.5.2,<0.7.0",


### PR DESCRIPTION
My tests repeatedly failed due to the definition of development
dev-dependencies as optional-dependencies. In the meanwhile, pip merged
the support for dependency-groups in February, 2025.

https://github.com/pypa/pip/commit/e930fee6b3c2a3a14c3e99350c01601eea1a529b

pip 25.1 is the first version containing this feature.
Debian Trixie ships a recent enough pip via apt:

https://packages.debian.org/de/trixie/python3-pip

Ubuntu 25.10 ships a recent enough pip.

https://packages.ubuntu.com/questing/python3-pip

However, pip can just install itself for the current user using `pipx`:

```
$ pipx install pip
```

`pipx` is available in the Debian and Ubuntu package sources.

https://packages.debian.org/sid/pipx
https://packages.ubuntu.com/plucky/pipx

Nevertheless, using `uv` for development is better in any case, since it
provides dependency pinning out-of-the-box.
