### PR TITLE
Transport Separation: strictly separate connect() calls and inits

### DIFF
--- a/src/gallia/command/base.py
+++ b/src/gallia/command/base.py
@@ -513,7 +513,12 @@ class Scanner(AsyncScript, ABC):
             else:
                 await self.dumpcap.sync()
 
-        self.transport = await load_transport(self.config.target).connect(self.config.target)
+        try:
+            # If there is no transport yet, accessing self.transport will raise a RuntimeError
+            await self.transport.connect()
+        except RuntimeError:
+            self.transport = load_transport(self.config.target)
+            await self.transport.connect()
 
     async def teardown(self) -> None:
         await self.transport.close()

--- a/src/gallia/commands/discover/find_xcp.py
+++ b/src/gallia/commands/discover/find_xcp.py
@@ -85,7 +85,8 @@ class CanFindXCP(FindXCP):
             f"{RawCANTransport.SCHEME}://{self.config.xcp_can_iface}?is_extended={str(self.config.extended).lower()}"
             + ("&is_fd=true" if self.config.can_fd else "")
         )
-        transport = await RawCANTransport.connect(target)
+        transport = RawCANTransport(target)
+        await transport.connect()
         endpoints = []
 
         sniff_time: int = self.config.sniff_time

--- a/src/gallia/commands/discover/uds/isotp.py
+++ b/src/gallia/commands/discover/uds/isotp.py
@@ -66,7 +66,8 @@ class IsotpDiscoverer(UDSDiscoveryScanner):
             logger.result("----------------------------")
             logger.result(f"Probing ECU: {target}")
 
-            transport = await ISOTPTransport.connect(target)
+            transport = ISOTPTransport(target)
+            await transport.connect()
             uds_client = UDSClient(transport, timeout=2)
             logger.result(f"reading device description at {g_repr(did)}")
             try:
@@ -106,7 +107,8 @@ class IsotpDiscoverer(UDSDiscoveryScanner):
         return frame
 
     async def main(self) -> None:
-        transport = await RawCANTransport.connect(self.config.target)
+        transport = RawCANTransport(self.config.target)
+        await transport.connect()
         found = []
 
         sniff_time: int = self.config.sniff_time

--- a/src/gallia/commands/fuzz/uds/pdu.py
+++ b/src/gallia/commands/fuzz/uds/pdu.py
@@ -57,7 +57,8 @@ class PDUFuzzer(UDSScanner):
 
     async def observe_can_messages(self, can_ids: list[int]) -> None:
         can_url = self.config.target.url._replace(scheme=RawCANTransport.SCHEME)
-        transport = await RawCANTransport.connect(TargetURI(can_url.geturl()))
+        transport = RawCANTransport(TargetURI(can_url.geturl()))
+        await transport.connect()
         transport.set_filter(can_ids, inv_filter=False)
 
         try:

--- a/src/gallia/commands/primitive/uds/xcp.py
+++ b/src/gallia/commands/primitive/uds/xcp.py
@@ -47,8 +47,8 @@ class SimpleTestXCP(Scanner):
         self.service: XCPService
 
     async def setup(self) -> None:
-        transport_type = load_transport(self.config.target)
-        transport = await transport_type.connect(self.config.target)
+        transport = load_transport(self.config.target)
+        await transport.connect()
 
         if isinstance(transport, RawCANTransport):
             assert self.config.can_master is not None and self.config.can_slave is not None

--- a/src/gallia/commands/script/flexray.py
+++ b/src/gallia/commands/script/flexray.py
@@ -13,6 +13,7 @@ assert sys.platform == "win32"
 
 from gallia.command import AsyncScript
 from gallia.transports._ctypes_vector_xl_wrapper import FlexRayCtypesBackend
+from gallia.transports.base import TargetURI
 from gallia.transports.flexray_vector import FlexRayFrame, RawFlexRayTransport, parse_frame_type
 
 
@@ -47,7 +48,8 @@ class FRDump(AsyncScript):
         return res
 
     async def main(self) -> None:
-        tp = await RawFlexRayTransport.connect("fr-raw:", None)
+        tp = RawFlexRayTransport(TargetURI("fr-raw:"))
+        await tp.connect()
 
         if len(self.config.slot) > 0:
             tp.add_block_all_filter()

--- a/src/gallia/plugins/plugin.py
+++ b/src/gallia/plugins/plugin.py
@@ -68,7 +68,7 @@ def load_transports() -> list[type[BaseTransport]]:
     return transports
 
 
-def load_transport(target: TargetURI) -> type[BaseTransport]:
+def load_transport(target: TargetURI) -> BaseTransport:
     """Selects a transport class depending on a TargetURI.
     The lookup is performed in builtin transports and all
     classes behind the ``gallia_transports`` entry_point.
@@ -76,7 +76,7 @@ def load_transport(target: TargetURI) -> type[BaseTransport]:
     for plugin in load_plugins():
         for transport in plugin.transports():
             if target.scheme == transport.SCHEME:
-                return transport
+                return transport(target)
 
     raise ValueError(f"no transport for {target}")
 

--- a/src/gallia/services/uds/core/client.py
+++ b/src/gallia/services/uds/core/client.py
@@ -54,7 +54,7 @@ class UDSClient:
 
     async def reconnect_unsafe(self, timeout: int | None = None) -> None:
         """Calls the underlying transport to trigger a reconnect without locking"""
-        self.transport = await self.transport.reconnect(timeout)
+        await self.transport.reconnect(timeout)
         logger.debug("Reconnected transport successfully")
         await self.connect()
 

--- a/src/gallia/services/uds/server.py
+++ b/src/gallia/services/uds/server.py
@@ -867,7 +867,8 @@ if sys.platform.startswith("linux"):
 
     class ISOTPUDSServerTransport(UDSServerTransport):
         async def run(self) -> None:
-            transport = await ISOTPTransport.connect(self.target)
+            transport = ISOTPTransport(self.target)
+            await transport.connect()
 
             while True:
                 try:

--- a/src/gallia/transports/dummy.py
+++ b/src/gallia/transports/dummy.py
@@ -2,17 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Self
-
-from gallia.transports import TargetURI
 from gallia.transports.base import BaseTransport
 
 
 class DummyTransport(BaseTransport, scheme="dummy"):
-    @classmethod
-    async def connect(cls, target: str | TargetURI, timeout: float | None = None) -> Self:
-        t = target if isinstance(target, TargetURI) else TargetURI(target)
-        return cls(t)
+    async def connect(self, timeout: float | None = None) -> None:
+        pass
 
     async def close(self) -> None:
         pass

--- a/src/gallia/transports/flexray_vector.py
+++ b/src/gallia/transports/flexray_vector.py
@@ -79,11 +79,9 @@ class RawFlexRayTransport(BaseTransport, scheme="fr-raw"):
     @classmethod
     async def connect(
         cls,
-        target: str | TargetURI,
         timeout: float | None = None,
-    ) -> Self:
-        t = TargetURI(target) if isinstance(target, str) else target
-        return cls(t)
+    ) -> None:
+        pass
 
     async def write_frame_unsafe(self, frame: FlexRayFrame) -> None:
         await self.backend.transmit(frame.slot_id, frame.data)
@@ -324,12 +322,10 @@ class FlexRayTPLegacyTransport(BaseTransport, scheme="fr-tp-legacy"):
     @classmethod
     async def connect(
         cls,
-        target: str | TargetURI,
         timeout: float | None = None,
-    ) -> Self:
-        t = TargetURI(target) if isinstance(target, str) else target
-        fr_raw = await RawFlexRayTransport.connect("fr-raw:", timeout)
-        return cls(t, fr_raw)
+    ) -> None:
+        fr_raw = RawFlexRayTransport(TargetURI("fr-raw:"))
+        await fr_raw.connect(timeout)
 
     async def write_bytes(self, data: bytes) -> None:
         frame = FlexRayFrame(

--- a/src/gallia/transports/tcp.py
+++ b/src/gallia/transports/tcp.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
-from typing import Self
 
 from gallia.log import get_logger
 from gallia.transports.base import BaseTransport, LinesTransportMixin, TargetURI
@@ -15,29 +14,31 @@ class TCPTransport(BaseTransport, scheme="tcp"):
     def __init__(
         self,
         target: TargetURI,
-        reader: asyncio.StreamReader,
-        writer: asyncio.StreamWriter,
     ) -> None:
         super().__init__(target)
-        self.reader = reader
-        self.writer = writer
 
-    @classmethod
-    async def connect(cls, target: str | TargetURI, timeout: float | None = None) -> Self:
-        t = target if isinstance(target, TargetURI) else TargetURI(target)
-        cls.check_scheme(t)
+        self.reader: asyncio.StreamReader | None = None
+        self.writer: asyncio.StreamWriter | None = None
 
-        reader, writer = await asyncio.wait_for(
-            asyncio.open_connection(t.hostname, t.port), timeout
+    async def connect(self, timeout: float | None = None) -> None:
+        if self.reader is not None or self.writer is not None:
+            logger.warning("Unix socket already connected, not connecting a second time!")
+            return
+
+        self.reader, self.writer = await asyncio.wait_for(
+            asyncio.open_connection(self.target.hostname, self.target.port), timeout
         )
-        return cls(t, reader, writer)
 
     async def close(self) -> None:
-        if self.is_closed:
+        if self.writer is None:  # FIXME: Check below whether self.reader is None is also needed
+            logger.debug("TCP socket is already closed")
             return
-        self.is_closed = True
+
         self.writer.close()
         await self.writer.wait_closed()
+        # self.reader.feed_eof() FIXME: Is this needed?
+
+        self.reader, self.writer = None, None
 
     async def write(
         self,
@@ -45,6 +46,9 @@ class TCPTransport(BaseTransport, scheme="tcp"):
         timeout: float | None = None,
         tags: list[str] | None = None,
     ) -> int:
+        if self.writer is None:
+            raise RuntimeError("Writer not connected, cannot write!")
+
         t = tags + ["write"] if tags is not None else ["write"]
         logger.trace(data.hex(), extra={"tags": t})
 
@@ -57,6 +61,9 @@ class TCPTransport(BaseTransport, scheme="tcp"):
         timeout: float | None = None,
         tags: list[str] | None = None,
     ) -> bytes:
+        if self.reader is None:
+            raise RuntimeError("Reader not connected, cannot read!")
+
         data = await asyncio.wait_for(self.reader.read(self.BUFSIZE), timeout)
 
         t = tags + ["read"] if tags is not None else ["read"]
@@ -66,7 +73,11 @@ class TCPTransport(BaseTransport, scheme="tcp"):
 
 class TCPLinesTransport(LinesTransportMixin, TCPTransport, scheme="tcp-lines"):
     def get_reader(self) -> asyncio.StreamReader:
+        if self.reader is None:
+            raise RuntimeError("Reader not connected!")
         return self.reader
 
     def get_writer(self) -> asyncio.StreamWriter:
+        if self.writer is None:
+            raise RuntimeError("Writer not connected!")
         return self.writer


### PR DESCRIPTION
The transport object itself is supposed to last as long as a scanner
object, which for example allows to externally create it and pass it to
the scanner object before calling `entry_point`.

The connection itself, however, can be disconnected and reconnected
multiple times, but without creating new transport objects.