### PR TITLE
feat(TesterPresent): Let TesterPresent only fire for inactivity

### DIFF
--- a/src/gallia/commands/primitive/uds/ping.py
+++ b/src/gallia/commands/primitive/uds/ping.py
@@ -45,7 +45,7 @@ class PingPrimitive(UDSScanner):
 
         i = 1
         while True:
-            ret = await self.ecu.ping()
+            ret = await self.ecu.tester_present(suppress_response=False)
             if isinstance(ret, NegativeResponse):
                 logger.warning(ret)
             logger.result("ECU is alive!")

--- a/src/gallia/services/uds/core/client.py
+++ b/src/gallia/services/uds/core/client.py
@@ -156,20 +156,6 @@ class UDSClient:
         logger.debug(f"{request} failed after retry loop")
         raise last_exception
 
-    async def _tester_present(
-        self, suppress_resp: bool = False, config: UDSRequestConfig | None = None
-    ) -> service.UDSResponse | None:
-        config = config if config is not None else UDSRequestConfig()
-        timeout = config.timeout if config.timeout else self.timeout
-        if suppress_resp:
-            pdu = service.TesterPresentRequest(suppress_response=True).pdu
-            tags = config.tags if config.tags is not None else []
-            logger.debug(pdu.hex(), extra={"tags": ["write", "uds"] + tags})
-            await self.transport.write(pdu, timeout, config.tags)
-            # TODO: This is not fail safe: What if there is an answer???
-            return None
-        return await self.tester_present(False, config)
-
     async def send_raw(
         self, pdu: bytes, config: UDSRequestConfig | None = None
     ) -> service.NegativeResponse | service.PositiveResponse:

--- a/src/gallia/services/uds/ecu.py
+++ b/src/gallia/services/uds/ecu.py
@@ -107,16 +107,6 @@ class ECU(UDSClient):
     ) -> ECUProperties:
         return ECUProperties()
 
-    async def ping(
-        self, config: UDSRequestConfig | None = None
-    ) -> service.NegativeResponse | service.TesterPresentResponse:
-        """Send an UDS TesterPresent message.
-
-        Returns:
-            UDS response.
-        """
-        return await self.tester_present(suppress_response=False, config=config)
-
     async def read_session(self, config: UDSRequestConfig | None = None) -> int:
         """Read out current session.
 
@@ -355,7 +345,7 @@ class ECU(UDSClient):
             logger.info(f"Waiting for ECU{'.' * i}")
             try:
                 await asyncio.sleep(sleep_time)
-                await self.ping(config=config)
+                await self.tester_present(suppress_response=False, config=config)
                 break
             # When the ECU is not ready, we expect an UDSException, e.g. MissingResponse.
             # On ConnectionError, we additionally reconnect the transport to ensure connectivity.

--- a/src/gallia/services/uds/ecu.py
+++ b/src/gallia/services/uds/ecu.py
@@ -338,13 +338,12 @@ class ECU(UDSClient):
 
     async def _wait_for_ecu_endless_loop(self, sleep_time: float) -> None:
         """Internal method with endless loop in case of no answer from ECU"""
-        config = UDSRequestConfig(timeout=0.5, max_retry=0, skip_hooks=True)
+        config = UDSRequestConfig(timeout=sleep_time, max_retry=0, skip_hooks=True)
         i = -1
         while True:
             i = (i + 1) % 4
             logger.info(f"Waiting for ECU{'.' * i}")
             try:
-                await asyncio.sleep(sleep_time)
                 await self.tester_present(suppress_response=False, config=config)
                 break
             # When the ECU is not ready, we expect an UDSException, e.g. MissingResponse.
@@ -371,7 +370,7 @@ class ECU(UDSClient):
             await self.tester_present_task.stop()
 
         try:
-            await asyncio.wait_for(self._wait_for_ecu_endless_loop(0.5), timeout=timeout)
+            await asyncio.wait_for(self._wait_for_ecu_endless_loop(1), timeout=timeout)
             return True
         except TimeoutError:
             logger.critical("Timeout while waiting for ECU!")


### PR DESCRIPTION
Instead of sending regularily, let TesterPresent only become active if there was no other UDS activity for a certain amount of time.

This feature can be enabled/disabled in config file and by default is disabled to retain backwards compatibility.