### PR TITLE
feat: Add dummy transport

### DIFF
--- a/src/gallia/transports/__init__.py
+++ b/src/gallia/transports/__init__.py
@@ -6,12 +6,14 @@ import sys
 
 from gallia.transports.base import BaseTransport, TargetURI
 from gallia.transports.doip import DoIPTransport
+from gallia.transports.dummy import DummyTransport
 from gallia.transports.hsfz import HSFZTransport
 from gallia.transports.schemes import TransportScheme
 from gallia.transports.tcp import TCPLinesTransport, TCPTransport
 
 registry: list[type[BaseTransport]] = [
     DoIPTransport,
+    DummyTransport,
     HSFZTransport,
     TCPLinesTransport,
     TCPTransport,
@@ -20,6 +22,7 @@ registry: list[type[BaseTransport]] = [
 __all__ = [
     "BaseTransport",
     "DoIPTransport",
+    "DummyTransport",
     "HSFZTransport",
     "TCPLinesTransport",
     "TCPTransport",

--- a/src/gallia/transports/dummy.py
+++ b/src/gallia/transports/dummy.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: AISEC Pentesting Team
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Self
+
+from gallia.transports import TargetURI
+from gallia.transports.base import BaseTransport
+
+
+class DummyTransport(BaseTransport, scheme="dummy"):
+    @classmethod
+    async def connect(cls, target: str | TargetURI, timeout: float | None = None) -> Self:
+        t = target if isinstance(target, TargetURI) else TargetURI(target)
+        return cls(t)
+
+    async def close(self) -> None:
+        pass
+
+    async def read(self, timeout: float | None = None, tags: list[str] | None = None) -> bytes:
+        return b""
+
+    async def write(
+        self, data: bytes, timeout: float | None = None, tags: list[str] | None = None
+    ) -> int:
+        return len(data)

--- a/src/gallia/transports/schemes.py
+++ b/src/gallia/transports/schemes.py
@@ -8,6 +8,7 @@ from enum import StrEnum, unique
 TCP = "tcp"
 TCP_LINES = "tcp-lines"
 DOIP = "doip"
+DUMMY = "dummy"
 
 
 if sys.platform.startswith("linux"):
@@ -17,10 +18,11 @@ if sys.platform.startswith("linux"):
         TCP = TCP
         TCP_LINES = TCP_LINES
         DOIP = DOIP
+        DUMMY = DUMMY
+
         HSFZ = "hsfz"
         UNIX = "unix"
         UNIX_LINES = "unix-lines"
-
         ISOTP = "isotp"
         CAN_RAW = "can-raw"
 
@@ -32,6 +34,7 @@ if sys.platform == "win32":
         TCP = TCP
         TCP_LINES = TCP_LINES
         DOIP = DOIP
+        DUMMY = DUMMY
 
         FLEXRAY_RAW = "fr-raw"
         FLEXRAY_TP_LEGACY = "fr-tp-legacy"


### PR DESCRIPTION
Can be used to circumvent unnecessary connects, e.g. if a scanner also supports dry runs, it can override the given target with a `dummy:\\` target.