### PR TITLE
Add more base classes for more fine grained parameters

### DIFF
--- a/src/gallia/cli/netzteil.py
+++ b/src/gallia/cli/netzteil.py
@@ -7,8 +7,7 @@ from typing import Any, Literal, Self
 from pydantic import field_serializer, model_validator
 
 from gallia.cli.gallia import parse_and_run
-from gallia.command import AsyncScript
-from gallia.command.base import AsyncScriptConfig, ScannerConfig
+from gallia.command.base import LockableScript, LockableScriptConfig, MetaScannerConfig
 from gallia.command.config import Field, Idempotent
 from gallia.power_supply import power_supply_drivers
 from gallia.power_supply.base import BasePowerSupplyDriver
@@ -17,12 +16,12 @@ from gallia.transports import TargetURI
 from gallia.utils import strtobool
 
 
-class CLIConfig(AsyncScriptConfig):
+class CLIConfig(LockableScriptConfig):
     power_supply: Idempotent[PowerSupplyURI] = Field(
         description="URI specifying the location of the powersupply",
         metavar="URI",
         short="t",
-        config_section=ScannerConfig._config_section,
+        config_section=MetaScannerConfig._config_section,
     )
     channel: int = Field(description="the channel number to control", short="c")
     attr: Literal["voltage", "current", "output"] = Field(
@@ -52,7 +51,7 @@ class SetCLIConfig(CLIConfig):
     value: str = Field(positional=True)
 
 
-class CLI(AsyncScript, ABC):
+class CLI(LockableScript, ABC):
     def __init__(self, config: CLIConfig):
         super().__init__(config)
         self.config: CLIConfig = config

--- a/src/gallia/command/__init__.py
+++ b/src/gallia/command/__init__.py
@@ -2,13 +2,15 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from gallia.command.base import AsyncScript, BaseCommand, Scanner
+from gallia.command.base import AsyncScript, BaseCommand, LockableScript, MetaScanner, Scanner
 from gallia.command.uds import UDSDiscoveryScanner, UDSScanner
 
 __all__ = [
     "BaseCommand",
     "AsyncScript",
     "Scanner",
+    "LockableScript",
+    "MetaScanner",
     "UDSScanner",
     "UDSDiscoveryScanner",
 ]

--- a/src/gallia/commands/discover/doip.py
+++ b/src/gallia/commands/discover/doip.py
@@ -9,8 +9,7 @@ from collections.abc import Iterable
 from itertools import product
 from urllib.parse import parse_qs, urlparse
 
-from gallia.command import AsyncScript
-from gallia.command.base import AsyncScriptConfig
+from gallia.command.base import MetaScanner, MetaScannerConfig
 from gallia.command.config import AutoInt, Field
 from gallia.log import get_logger
 from gallia.net import net_if_broadcast_addrs
@@ -33,7 +32,7 @@ from gallia.transports.doip import (
 logger = get_logger(__name__)
 
 
-class DoIPDiscovererConfig(AsyncScriptConfig):
+class DoIPDiscovererConfig(MetaScannerConfig):
     start: AutoInt = Field(
         0x00, description="Set start address of TargetAddress search range", metavar="INT"
     )
@@ -57,7 +56,7 @@ class DoIPDiscovererConfig(AsyncScriptConfig):
     )
 
 
-class DoIPDiscoverer(AsyncScript):
+class DoIPDiscoverer(MetaScanner):
     """This script scans for active DoIP endpoints and automatically enumerates allowed
     RoutingActivationTypes and known SourceAddresses. Once valid endpoints are acquired,
     the script continues to discover valid TargetAddresses that are accepted and respond

--- a/src/gallia/commands/discover/find_xcp.py
+++ b/src/gallia/commands/discover/find_xcp.py
@@ -9,8 +9,7 @@ from abc import ABC
 
 assert sys.platform.startswith("linux"), "unsupported platform"
 
-from gallia.command import AsyncScript
-from gallia.command.base import AsyncScriptConfig
+from gallia.command.base import MetaScanner, MetaScannerConfig
 from gallia.command.config import AutoInt, Field, Ranges
 from gallia.log import get_logger
 from gallia.services.uds.core.utils import bytes_repr, g_repr
@@ -20,7 +19,7 @@ from gallia.utils import can_id_repr
 logger = get_logger(__name__)
 
 
-class FindXCPConfig(AsyncScriptConfig):
+class FindXCPConfig(MetaScannerConfig):
     pass
 
 
@@ -45,7 +44,7 @@ class UdpFindXCPConfig(FindXCPConfig):
     udp_ports: Ranges = Field(description="List of UDP ports to test for XCP")
 
 
-class FindXCP(AsyncScript, ABC):
+class FindXCP(MetaScanner, ABC):
     """Find XCP Slave"""
 
     def __init__(self, config: FindXCPConfig):


### PR DESCRIPTION
This adds two new base classes between the existing AsyncScript and Scanner hierarchy.

Basically what happens is:
- The `lock_file` parameter from `GalliaBaseModel` gets moved down to the new `LockableScript`, to avoid unnecessary locks in any scripts if the user uses a config file with a lock file set
- The `power_supply`, `power_cycle` and `power_cycle_sleep` parameters get moved up to the new `MetaScanner` class, to also allow discovery scripts to make use of the powercycle functionality automatically and make further use of the power supply if necessary
- Some scripts have been adjusted to use one of the new base classes as their parent class