### PR TITLE
fix: Please pydantic linter and use method to parse dict

### DIFF
--- a/src/gallia/transports/can.py
+++ b/src/gallia/transports/can.py
@@ -158,7 +158,7 @@ class RawCANTransport(BaseTransport, scheme="can-raw"):
 
         sock = s.socket(s.PF_CAN, s.SOCK_RAW, CAN_RAW)
         sock.bind((t.hostname,))
-        config = RawCANConfig(**t.qs_flat)
+        config = RawCANConfig.model_validate(t.qs_flat)
 
         if config.is_fd is True:
             sock.setsockopt(SOL_CAN_RAW, CAN_RAW_FD_FRAMES, 1)

--- a/src/gallia/transports/doip.py
+++ b/src/gallia/transports/doip.py
@@ -817,7 +817,7 @@ class DoIPTransport(BaseTransport, scheme="doip"):
             raise ValueError("no hostname specified")
 
         port = t.port if t.port is not None else 13400
-        config = DoIPConfig(**t.qs_flat)
+        config = DoIPConfig.model_validate(t.qs_flat)
         conn = await asyncio.wait_for(
             cls._connect(
                 t.hostname,

--- a/src/gallia/transports/flexray_vector.py
+++ b/src/gallia/transports/flexray_vector.py
@@ -55,7 +55,7 @@ class RawFlexRayTransport(BaseTransport, scheme="fr-raw"):
         super().__init__(target)
 
         self.check_scheme(target)
-        self.config = RawFlexRayConfig(**target.qs_flat)
+        self.config = RawFlexRayConfig.model_validate(target.qs_flat)
 
         self.backend = _ctypes_vector_xl_wrapper.FlexRayCtypesBackend.create(
             channel_no=self.config.channel_no,
@@ -312,7 +312,7 @@ class FlexRayTPLegacyTransport(BaseTransport, scheme="fr-tp-legacy"):
         super().__init__(target)
 
         self.check_scheme(target)
-        self.config = FlexrayTPLegacyConfig(**target.qs_flat)
+        self.config = FlexrayTPLegacyConfig.model_validate(target.qs_flat)
         self.mutex = asyncio.Lock()
 
         self.fr_raw = fr_raw

--- a/src/gallia/transports/hsfz.py
+++ b/src/gallia/transports/hsfz.py
@@ -336,7 +336,7 @@ class HSFZTransport(BaseTransport, scheme="hsfz"):
             raise ValueError("no hostname specified")
 
         port = t.port if t.port is not None else 6801
-        config = HSFZConfig(**t.qs_flat)
+        config = HSFZConfig.model_validate(t.qs_flat)
         conn = await HSFZConnection.connect(
             t.hostname,
             port,


### PR DESCRIPTION
The vscode linters are not happy with the ** variant. Just use the
intended method for parsing pydantic stuff.
