### PR TITLE
Fix(pydantic): Store original field info to work around changes in pydantic 2.12

### DIFF
--- a/src/gallia/cli/gallia.py
+++ b/src/gallia/cli/gallia.py
@@ -45,6 +45,7 @@ def _create_parser_from_command(
     model_type = create_model(
         f"_dynamic_{command.CONFIG_TYPE}_{model_counter}", __base__=command.CONFIG_TYPE
     )
+    model_type._original_field_infos = command.CONFIG_TYPE._original_field_infos
     extra_defaults[model_type] = config_attributes
 
     setattr(model_type, _CLASS_ATTR, command)

--- a/src/gallia/command/config.py
+++ b/src/gallia/command/config.py
@@ -373,14 +373,15 @@ class GalliaBaseModel(BaseCommand, ABC):
     def attributes_from_config(cls, config: Config, source: str = "config file") -> dict[str, Any]:
         result = {}
 
-        for name, info in cls._original_field_infos.items():
-            if isinstance(info, ConfigArgFieldInfo):
-                config_attribute = (
-                    f"{info.config_section}.{name}" if info.config_section != "" else name
-                )
+        if (original_infos := cls._original_field_infos) is not None:
+            for name, info in original_infos.items():
+                if isinstance(info, ConfigArgFieldInfo):
+                    config_attribute = (
+                        f"{info.config_section}.{name}" if info.config_section != "" else name
+                    )
 
-                if (value := config.get_value(config_attribute)) is not None:
-                    result[name] = (f"{source} ({info.config_section}:{name})", value)
+                    if (value := config.get_value(config_attribute)) is not None:
+                        result[name] = (f"{source} ({info.config_section}:{name})", value)
 
         return result
 
@@ -388,11 +389,12 @@ class GalliaBaseModel(BaseCommand, ABC):
     def attributes_from_env(cls) -> dict[str, Any]:
         result = {}
 
-        for name, info in cls._original_field_infos.items():
-            if isinstance(info, ConfigArgFieldInfo):
-                config_attribute = f"GALLIA_{name.upper()}"
+        if (original_infos := cls._original_field_infos) is not None:
+            for name, info in original_infos.items():
+                if isinstance(info, ConfigArgFieldInfo):
+                    config_attribute = f"GALLIA_{name.upper()}"
 
-                if (value := os.getenv(config_attribute)) is not None:
-                    result[name] = (f"environment variable ({config_attribute})", value)
+                    if (value := os.getenv(config_attribute)) is not None:
+                        result[name] = (f"environment variable ({config_attribute})", value)
 
         return result

--- a/src/gallia/command/config.py
+++ b/src/gallia/command/config.py
@@ -373,7 +373,7 @@ class GalliaBaseModel(BaseCommand, ABC):
     def attributes_from_config(cls, config: Config, source: str = "config file") -> dict[str, Any]:
         result = {}
 
-        for name, info in cls.model_fields.items():
+        for name, info in cls._original_field_infos.items():
             if isinstance(info, ConfigArgFieldInfo):
                 config_attribute = (
                     f"{info.config_section}.{name}" if info.config_section != "" else name
@@ -388,7 +388,7 @@ class GalliaBaseModel(BaseCommand, ABC):
     def attributes_from_env(cls) -> dict[str, Any]:
         result = {}
 
-        for name, info in cls.model_fields.items():
+        for name, info in cls._original_field_infos.items():
             if isinstance(info, ConfigArgFieldInfo):
                 config_attribute = f"GALLIA_{name.upper()}"
 

--- a/src/gallia/pydantic_argparse/__init__.py
+++ b/src/gallia/pydantic_argparse/__init__.py
@@ -12,28 +12,8 @@ The public interface exposed by this package is the declarative and typed
 `ArgumentParser` class, as well as the package "dunder" metadata.
 """
 
-# Local
-from pydantic import BaseModel, ConfigDict
-
 from gallia.pydantic_argparse.argparse import ArgumentParser
-
-
-class BaseArgument(BaseModel):
-    """Base pydantic model for argument groups."""
-
-    model_config = ConfigDict(json_schema_extra={"subcommand": False})
-
-
-class BaseCommand(BaseModel):
-    """Base pydantic model for command groups.
-
-    This class is only a convenience base class that sets the
-    `model_config` parameter to have the `json_schema_extra` parameter to
-    have `subcommand=True`.
-    """
-
-    model_config = ConfigDict(json_schema_extra={"subcommand": True}, defer_build=True)
-
+from gallia.pydantic_argparse.utils.pydantic import BaseArgument, BaseCommand
 
 # Public Re-Exports
 __all__ = (

--- a/src/gallia/pydantic_argparse/argparse/parser.py
+++ b/src/gallia/pydantic_argparse/argparse/parser.py
@@ -309,16 +309,19 @@ class ArgumentParser(argparse.ArgumentParser, Generic[PydanticModelT]):
                 ):
                     field.extra_default = self.extra_defaults[model][field.name]
 
-                if isinstance(field.info, ArgFieldInfo) and field.info.hidden:
+                if isinstance(field.original_info, ArgFieldInfo) and field.original_info.hidden:
                     continue
 
-                if isinstance(field.info, ArgFieldInfo) and field.info.group is not None:
-                    if field.info.group not in explicit_groups:
-                        explicit_groups[field.info.group] = self.add_argument_group(
-                            field.info.group
+                if (
+                    isinstance(field.original_info, ArgFieldInfo)
+                    and field.original_info.group is not None
+                ):
+                    if field.original_info.group not in explicit_groups:
+                        explicit_groups[field.original_info.group] = self.add_argument_group(
+                            field.original_info.group
                         )
 
-                    parsers.add_field(explicit_groups[field.info.group], field)
+                    parsers.add_field(explicit_groups[field.original_info.group], field)
                     added = True
 
                 if not added:

--- a/src/gallia/pydantic_argparse/utils/pydantic.py
+++ b/src/gallia/pydantic_argparse/utils/pydantic.py
@@ -101,13 +101,19 @@ class PydanticField:
         """
         # Quick fix for pydantic 2.12 not returning the original field infos
         for name, info in model.model_fields.items():
-            if isinstance(model, BaseCommand) or issubclass(model, BaseCommand):
+            original_info: FieldInfo | None = None
+
+            if (
+                isinstance(model, BaseCommand)
+                or isinstance(model, type)
+                and issubclass(model, BaseCommand)
+            ):
                 try:
-                    yield cls(name, info, model._original_field_infos[name])
+                    original_info = model._original_field_infos[name]
                 except KeyError:
-                    yield cls(name, info)
-            else:
-                yield cls(name, info)
+                    pass
+
+            yield cls(name, info, original_info)
 
     def _get_type(self, annotation: type | None) -> type | tuple[type | None, ...] | None:
         origin = get_origin(annotation)


### PR DESCRIPTION
pydantic 2.12 introduces a change that discourages using subclasses of the FieldInfo class by making it final and often replaces the original object with a new one of the FieldInfo class. As a consequence, the extra information of any object of a subclass is lost.

This commit therefore stores the original FieldInfos during class instantiation in the _original_fields variable. These fields can then be used by the parser to retrieve any additional information that is not present in the potentially changed fields.

This commit does not yet address the inheritance problem.