### PR TITLE
fix(power_supply): Hold mutex while performing power cycles

### DIFF
--- a/src/gallia/commands/scan/uds/reset.py
+++ b/src/gallia/commands/scan/uds/reset.py
@@ -136,7 +136,6 @@ class ResetScanner(UDSScanner):
                 )
                 try:
                     await self.ecu.power_cycle(self.config.power_cycle_sleep)
-                    await self.ecu.wait_for_ecu()
                 except (TimeoutError, ConnectionError) as e:
                     logger.error(f"Failed to recover ECU: {g_repr(e)}; exit")
                     sys.exit(1)


### PR DESCRIPTION
Additionally, there is no need to call `reconnect` or `wait_for_ecu` after calling `power_cycle`.

`wait_for_ecu`  is called within `power_cycle`, and `reconnect` within `wait_for_ecu`...