### PR TITLE
tests: Fix python versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.11', '3.12', '3.13', '3.13t', '3.14', '3.14t']
+        python-version: ['3.11', '3.12', '3.13', '3.14', '3.14t']
 
     runs-on: ubuntu-latest
 
@@ -50,7 +50,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.11', '3.12', '3.13', '3.14', '3.14t']
 
     runs-on: ubuntu-latest
     container: debian:trixie


### PR DESCRIPTION
zstd is broken on 3.13 let's start with 3.14t
