### PR TITLE
fix: Address empty responses

### DIFF
--- a/.github/workflows/assign_reviewers.py
+++ b/.github/workflows/assign_reviewers.py
@@ -44,7 +44,7 @@ class CLIWrapper:
 
     def get_files(self) -> list[str]:
         raw_resp = self.call_gh_api(urljoin(self.repo_api_base, f"pulls/{self.pr}/files"))
-        return [r["filename"] for r in raw_resp]
+        return [r["filename"] for r in raw_resp if "filename" in r]
 
     def get_mr_sha(self) -> str:
         raw_resp = self.call_gh_api(urljoin(self.repo_api_base, f"pulls/{self.pr}"))
@@ -56,6 +56,9 @@ class CLIWrapper:
         )
         authors = []
         for commit in raw_resp:
+            if "author" not in commit and "login" not in commit["author"]:
+                continue
+
             author = commit["author"]["login"]
             if "[bot]" in author:
                 continue
@@ -64,7 +67,7 @@ class CLIWrapper:
 
     def get_team_members(self, team: str) -> list[str]:
         raw_resp = self.call_gh_api(f"/orgs/{self.user}/teams/{team}/members")
-        return [r["login"] for r in raw_resp]
+        return [r["login"] for r in raw_resp if "login" in r]
 
     def get_mr_author(self) -> str:
         raw_resp = self.call_gh_api(urljoin(self.repo_api_base, f"pulls/{self.pr}"))


### PR DESCRIPTION
        Querying authors of touched files…
        Traceback (most recent call last):
          File "/__w/gallia/gallia/.github/workflows/assign_reviewers.py", line 133, in <module>
            main()
            ~~~~^^
          File "/__w/gallia/gallia/.github/workflows/assign_reviewers.py", line 103, in main
            for author in cli.get_authors(file):
                          ~~~~~~~~~~~~~~~^^^^^^
          File "/__w/gallia/gallia/.github/workflows/assign_reviewers.py", line 59, in get_authors
            author = commit["author"]["login"]
                     ~~~~~~~~~~~~~~~~^^^^^^^^^
        TypeError: 'NoneType' object is not subscriptable
        Error: Process completed with exit code 1.
