### PR TITLE
tests: Add infrastructure to unit test scanner modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,4 +145,5 @@ asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 filterwarnings = [
     "error::UserWarning",
+    "ignore::DeprecationWarning",
 ]

--- a/src/gallia/command/uds.py
+++ b/src/gallia/command/uds.py
@@ -87,6 +87,7 @@ class UDSScannerConfig(AsyncScriptConfig, cli_group="uds", config_section="galli
         None,
         description="If a transport is provided, it basically overrides 'target' and skips 'load_transport'.",
         hidden=True,
+        exclude=True,
     )
 
     @field_serializer("target", "power_supply")

--- a/tests/pytest/conftest.py
+++ b/tests/pytest/conftest.py
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: AISEC Pentesting Team
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Enable this here for debugging!
+# from gallia.log import setup_logging
+#
+# setup_logging()

--- a/tests/pytest/test_helpers.py
+++ b/tests/pytest/test_helpers.py
@@ -4,14 +4,11 @@
 
 import pytest
 
-from gallia.log import setup_logging
 from gallia.net import split_host_port
 from gallia.services.uds.core.utils import (
     address_and_size_length,
     uds_memory_parameters,
 )
-
-setup_logging()
 
 
 @pytest.mark.parametrize("hostport", ["[fec2::10]:4509823409582350", "hallo:3575983275498230"])

--- a/tests/pytest/test_scan_services.py
+++ b/tests/pytest/test_scan_services.py
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: AISEC Pentesting Team
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+from collections.abc import AsyncIterator
+
+import pytest
+
+from gallia.commands.scan.uds.services import ServicesScanner, ServicesScannerConfig
+from gallia.log import get_logger
+from gallia.services.uds import UDSIsoServices, UDSRequest, UDSResponse
+from gallia.services.uds.core.service import (
+    DiagnosticSessionControlRequest,
+    DiagnosticSessionControlResponse,
+)
+from gallia.services.uds.server import (
+    QueueServerTransport,
+    UDSServer,
+)
+from gallia.transports import DummyTransport, TargetURI
+
+logger = get_logger(__name__)
+
+
+class _TestTransport(DummyTransport, scheme="dummy"):
+    def __init__(
+        self,
+        target: TargetURI,
+        read_queue: asyncio.Queue[bytes],
+        write_queue: asyncio.Queue[bytes],
+    ) -> None:
+        super().__init__(target)
+        self.read_queue = read_queue
+        self.write_queue = write_queue
+
+    async def read(self, timeout: float | None = None, tags: list[str] | None = None) -> bytes:
+        async with asyncio.timeout(timeout):
+            return await self.read_queue.get()
+
+    async def write(
+        self,
+        data: bytes,
+        timeout: float | None = None,
+        tags: list[str] | None = None,
+    ) -> int:
+        await self.write_queue.put(data)
+        return len(data)
+
+
+class UDSTestServer(UDSServer):
+    @property
+    def supported_services(self) -> dict[int, dict[UDSIsoServices, list[int] | None]]:
+        return {
+            0x01: {
+                UDSIsoServices.DiagnosticSessionControl: [0x01, 0x02, 0x03],
+            }
+        }
+
+    async def respond_after_default(self, request: UDSRequest) -> UDSResponse | None:
+        match request:
+            case DiagnosticSessionControlRequest():
+                return DiagnosticSessionControlResponse(
+                    diagnostic_session_type=request.diagnostic_session_type,
+                    session_parameter_record=bytes([0xAF, 0xFE]),
+                )
+            case _:
+                raise NotImplementedError
+
+
+class TestScanServices:
+    @pytest.fixture()
+    async def transport(self) -> AsyncIterator[_TestTransport]:
+        read_queue: asyncio.Queue[bytes] = asyncio.Queue()
+        write_queue: asyncio.Queue[bytes] = asyncio.Queue()
+
+        self.server = UDSTestServer()
+        server_transport = QueueServerTransport(self.server, read_queue, write_queue)
+
+        await self.server.setup()
+        server_task = asyncio.create_task(server_transport.run())
+
+        yield _TestTransport(TargetURI("dummy:"), write_queue, read_queue)
+
+        server_task.cancel()
+        await server_task
+
+    @pytest.mark.asyncio()
+    async def test_basic_service_discovery(self, transport: _TestTransport) -> None:
+        config = ServicesScannerConfig(
+            target=TargetURI("dummy:"),
+            transport=transport,
+        )
+        scanner = ServicesScanner(config)
+
+        await scanner.entry_point()
+
+        assert len(scanner.result) == 1

--- a/tests/pytest/test_transports.py
+++ b/tests/pytest/test_transports.py
@@ -8,14 +8,10 @@ from collections.abc import AsyncIterator, Callable
 
 import pytest
 
-from gallia.log import setup_logging
 from gallia.transports import BaseTransport, TargetURI, TCPLinesTransport, TCPTransport
 
 listen_target = TargetURI("tcp://127.0.0.1:1234")
 test_data = [b"hello", b"tcp"]
-
-
-setup_logging()
 
 
 class TCPServer:


### PR DESCRIPTION
This one creates the required infrastructure to test scanning modules via pytest. The QueueTransport is needed as an in memory networking layer. Our UDSServer module is used to implement test specific behaviour of a DuT.


old:

Found this locally and almost deleted it during chore. This superseeds #496, but is very much WIP and not ready.