### PR TITLE
fix: Make review-script optional

### DIFF
--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   assign-reviewers:
+    continue-on-error: true
     runs-on: ubuntu-latest
     # FIXME: The current version of gh on default runners is outdated and fails its tasks due to this bug: https://github.com/cli/cli/pull/11835
     container: archlinux


### PR DESCRIPTION
Sometimes stuff fail, e.g., the Github API returns a 403; see here:
https://github.com/Fraunhofer-AISEC/gallia/actions/runs/19807282099/job/56743448316

Make this CI job optional, that it doesn't block merging stuff.
