### PR TITLE
Enable bugbear lints

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -41,17 +41,6 @@ $ sudo apt install pipx
 $ pipx install gallia
 ```
 
-### Debian Package
-
-The goal is to bring gallia into the Debian package repository.
-The package scripts are available on [salsa.debian.org](https://salsa.debian.org/python-team/packages/gallia/).
-The [Github Releases](https://github.com/Fraunhofer-AISEC/gallia/releases) starting with version v2.0.0a4 contain a Debian package.
-
-``` shell-session
-$ wcurl URL_FROM_RELEASE_PAGE
-$ sudo apt install ./gallia_VERSION_all.deb
-```
-
 ### NixOS
 
 ``` shell-session
@@ -137,10 +126,3 @@ If you are using a distribution package, setting up shell completions is already
 $ mkdir -p ~/.config/fish/completions
 $ register-python-argcomplete --shell fish gallia > ~/.config/fish/completions/gallia.fish
 ```
-
-### IDE Integration
-
-Just use [LSP](https://microsoft.github.io/language-server-protocol/).
-Most editors (e.g. [neovim](https://neovim.io/)) support the [Language Server Protocol](https://microsoft.github.io/language-server-protocol/).
-The required tools are listed as development dependencies in `pyproject.toml` and are automatically managed by `uv`.
-Please refer to the documentation of your text editor of choice for configuring LSP support.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,8 +98,7 @@ exclude = ["docs/", "src/gallia/services/xcp/types.py"]
 
 [tool.ruff.lint]
 select = [
-    # TODO: Enable this
-    # "B",    # flake8-bugbear
+    "B",    # flake8-bugbear
     "A",    # flake8-builtins
     "ASYNC",# flake8-async
     "C4",   # flake8-comprehensions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,8 +90,7 @@ exclude = ["docs/"]
 
 [tool.ruff.lint]
 select = [
-    # TODO: Enable this
-    # "B",    # flake8-bugbear
+    "B",    # flake8-bugbear
     "A",    # flake8-builtins
     "ASYNC",# flake8-async
     "C4",   # flake8-comprehensions

--- a/src/gallia/cli/cursed_hr.py
+++ b/src/gallia/cli/cursed_hr.py
@@ -1038,7 +1038,7 @@ class CursedHR:
                 nonlocal line_start
                 nonlocal display_entries
 
-                for _ in range(max_lines - 1):
+                for _ in range(max_lines - 1):  # noqa: B023
                     old_entry_start = entry_start
                     old_line_start = line_start
 
@@ -1058,7 +1058,7 @@ class CursedHR:
                 nonlocal entry_start
                 nonlocal line_start
 
-                if display_entries[0].entry_line_number == 0:
+                if display_entries[0].entry_line_number == 0:  # noqa: B023
                     if entry_start > 0:
                         entry_start = max(0, entry_start - 1)
                         line_start = -1

--- a/src/gallia/cli/cursed_hr.py
+++ b/src/gallia/cli/cursed_hr.py
@@ -1043,7 +1043,7 @@ class CursedHR:
                 nonlocal line_start
                 nonlocal display_entries
 
-                for _ in range(max_lines - 1):
+                for _ in range(max_lines - 1):  # noqa: B023
                     old_entry_start = entry_start
                     old_line_start = line_start
 
@@ -1064,7 +1064,7 @@ class CursedHR:
                 nonlocal entry_start
                 nonlocal line_start
 
-                if display_entries[0].entry_line_number == 0:
+                if display_entries[0].entry_line_number == 0:  # noqa: B023
                     if entry_start > 0:
                         entry_start = max(0, entry_start - 1)
                         line_start = -1

--- a/src/gallia/cli/cursed_hr.py
+++ b/src/gallia/cli/cursed_hr.py
@@ -1038,12 +1038,12 @@ class CursedHR:
             max_lines, max_columns = self.window.getmaxyx()
             max_lines -= 1
 
-            def page_up() -> None:
+            def page_up(max_lines: int = max_lines) -> None:
                 nonlocal entry_start
                 nonlocal line_start
                 nonlocal display_entries
 
-                for _ in range(max_lines - 1):  # noqa: B023
+                for _ in range(max_lines - 1):
                     old_entry_start = entry_start
                     old_line_start = line_start
 
@@ -1060,11 +1060,11 @@ class CursedHR:
 
                     display_entries = self.calculate_display_entries(entry_start, line_start)
 
-            def line_up() -> None:
+            def line_up(display_entries: list[DisplayEntry] = display_entries) -> None:
                 nonlocal entry_start
                 nonlocal line_start
 
-                if display_entries[0].entry_line_number == 0:  # noqa: B023
+                if display_entries[0].entry_line_number == 0:
                     if entry_start > 0:
                         entry_start = max(0, entry_start - 1)
                         line_start = -1

--- a/src/gallia/command/base.py
+++ b/src/gallia/command/base.py
@@ -126,12 +126,14 @@ class AsyncScript(ABC):
         self.db_handler: DBHandler | None = None
         self.log_file_handlers = []
 
-    async def setup(self) -> None: ...
+    async def setup(self) -> None:
+        return None
 
     @abstractmethod
     async def main(self) -> None: ...
 
-    async def teardown(self) -> None: ...
+    async def teardown(self) -> None:
+        return None
 
     async def run(self) -> int:
         await self.setup()

--- a/src/gallia/command/base.py
+++ b/src/gallia/command/base.py
@@ -127,12 +127,14 @@ class AsyncScript(ABC):
         self.db_handler: DBHandler | None = None
         self.log_file_handlers = []
 
-    async def setup(self) -> None: ...
+    async def setup(self) -> None:
+        return None
 
     @abstractmethod
     async def main(self) -> None: ...
 
-    async def teardown(self) -> None: ...
+    async def teardown(self) -> None:
+        return None
 
     async def run(self) -> int:
         await self.setup()

--- a/src/gallia/commands/script/vecu.py
+++ b/src/gallia/commands/script/vecu.py
@@ -99,14 +99,14 @@ class VirtualECU(AsyncScript, ABC):
                 case TransportScheme.UNIX_LINES:
                     transport = UnixUDSServerTransport(server, target)
                 case _:
-                    assert False
+                    raise ValueError(f"unsupported scheme: {target.scheme}")
 
         if sys.platform.startswith("win32"):
             match target.scheme:
                 case TransportScheme.TCP:
                     transport = TCPUDSServerTransport(server, target)
                 case _:
-                    assert False
+                    raise ValueError(f"unsupported scheme: {target.scheme}")
 
         try:
             await server.setup()

--- a/src/gallia/plugins/plugin.py
+++ b/src/gallia/plugins/plugin.py
@@ -116,7 +116,7 @@ def _merge_commands(
             try:
                 _merge_command_trees(cmd, value)
             except ValueError as e:
-                raise ValueError(f"{key} {str(e)}")
+                raise ValueError(f"{key} {str(e)}") from e
         else:
             raise ValueError(f"{key} ]: There already exists a leaf command")
 

--- a/src/gallia/services/uds/core/service.py
+++ b/src/gallia/services/uds/core/service.py
@@ -1237,7 +1237,9 @@ class ReadDataByIdentifierResponse(
     def pdu(self) -> bytes:
         pdu = pack("!B", self.RESPONSE_SERVICE_ID)
 
-        for data_identifier, data_record in zip(self.data_identifiers, self.data_records):
+        for data_identifier, data_record in zip(
+            self.data_identifiers, self.data_records, strict=False
+        ):
             pdu = pdu + to_bytes(data_identifier, 2) + data_record
 
         return pdu
@@ -1267,7 +1269,9 @@ class ReadDataByIdentifierResponse(
 
             return all(
                 req_id == resp_id
-                for req_id, resp_id in zip(request.data_identifiers, self.data_identifiers)
+                for req_id, resp_id in zip(
+                    request.data_identifiers, self.data_identifiers, strict=False
+                )
             )
 
         return request.data_identifiers[0] == self.data_identifiers[0]
@@ -1628,7 +1632,10 @@ class DefineByIdentifierRequest(
         )
 
         for source_data_identifier, position_in_source_data_record, memory_size in zip(
-            self.source_data_identifiers, self.positions_in_source_data_record, self.memory_sizes
+            self.source_data_identifiers,
+            self.positions_in_source_data_record,
+            self.memory_sizes,
+            strict=False,
         ):
             pdu = (
                 pdu
@@ -1730,7 +1737,7 @@ class DefineByMemoryAddressRequest(
 
         # In case the address_and_length_format_identifier is None, this calculates it based on the longest address and size
         # Otherwise it checks for all addresses and size if they can be represented with its length constraints.
-        for address, size in zip(self.memory_addresses, self.memory_sizes):
+        for address, size in zip(self.memory_addresses, self.memory_sizes, strict=False):
             computed_address_and_length_format_identifier, _, _ = uds_memory_parameters(
                 address, size, address_and_length_format_identifier
             )
@@ -1774,7 +1781,9 @@ class DefineByMemoryAddressRequest(
             self.address_and_length_format_identifier,
         )
 
-        for memory_address, memory_size in zip(self.memory_addresses, self.memory_sizes):
+        for memory_address, memory_size in zip(
+            self.memory_addresses, self.memory_sizes, strict=False
+        ):
             _, address, size = uds_memory_parameters(
                 memory_address, memory_size, self.address_and_length_format_identifier
             )
@@ -2741,7 +2750,7 @@ class ReportDTCExtDataRecordByDTCNumberResponse(
 
             self.dtc_and_status_record = dtc_and_status_record
 
-        for dtc_ext_data_record_number, dtc_ext_data_record in dtc_ext_data_records.items():
+        for dtc_ext_data_record_number, _dtc_ext_data_record in dtc_ext_data_records.items():
             check_range(dtc_ext_data_record_number, "dtc_ext_data_record_number", 0, 0xFD)
 
         self.dtc_ext_data_records = dtc_ext_data_records

--- a/src/gallia/services/uds/core/service.py
+++ b/src/gallia/services/uds/core/service.py
@@ -1238,7 +1238,7 @@ class ReadDataByIdentifierResponse(
         pdu = pack("!B", self.RESPONSE_SERVICE_ID)
 
         for data_identifier, data_record in zip(
-            self.data_identifiers, self.data_records, strict=False
+            self.data_identifiers, self.data_records, strict=True
         ):
             pdu = pdu + to_bytes(data_identifier, 2) + data_record
 
@@ -1270,7 +1270,7 @@ class ReadDataByIdentifierResponse(
             return all(
                 req_id == resp_id
                 for req_id, resp_id in zip(
-                    request.data_identifiers, self.data_identifiers, strict=False
+                    request.data_identifiers, self.data_identifiers, strict=True
                 )
             )
 
@@ -1635,7 +1635,7 @@ class DefineByIdentifierRequest(
             self.source_data_identifiers,
             self.positions_in_source_data_record,
             self.memory_sizes,
-            strict=False,
+            strict=True,
         ):
             pdu = (
                 pdu
@@ -1737,7 +1737,7 @@ class DefineByMemoryAddressRequest(
 
         # In case the address_and_length_format_identifier is None, this calculates it based on the longest address and size
         # Otherwise it checks for all addresses and size if they can be represented with its length constraints.
-        for address, size in zip(self.memory_addresses, self.memory_sizes, strict=False):
+        for address, size in zip(self.memory_addresses, self.memory_sizes, strict=True):
             computed_address_and_length_format_identifier, _, _ = uds_memory_parameters(
                 address, size, address_and_length_format_identifier
             )
@@ -1782,7 +1782,7 @@ class DefineByMemoryAddressRequest(
         )
 
         for memory_address, memory_size in zip(
-            self.memory_addresses, self.memory_sizes, strict=False
+            self.memory_addresses, self.memory_sizes, strict=True
         ):
             _, address, size = uds_memory_parameters(
                 memory_address, memory_size, self.address_and_length_format_identifier

--- a/src/gallia/services/uds/helpers.py
+++ b/src/gallia/services/uds/helpers.py
@@ -103,12 +103,12 @@ def parse_pdu(pdu: bytes, request: service.UDSRequest) -> service.UDSResponse:
             response = service.RawNegativeResponse(pdu)
             # RequestResponseMismatch takes priority over MalformedResponse
             if len(pdu) >= 3 and pdu[2] != request.service_id:
-                raise RequestResponseMismatch(request, response)
+                raise RequestResponseMismatch(request, response) from None
         else:
             response = service.RawPositiveResponse(pdu)
             # RequestResponseMismatch takes priority over MalformedResponse
             if response.service_id != request.service_id:
-                raise RequestResponseMismatch(request, response)
+                raise RequestResponseMismatch(request, response) from None
 
         raise MalformedResponse(request, response, str(e)) from e
 

--- a/src/gallia/services/uds/server.py
+++ b/src/gallia/services/uds/server.py
@@ -220,10 +220,10 @@ class UDSServer(ABC):
             self.state.session = 1
 
     async def setup(self) -> None:
-        pass
+        return None
 
     async def teardown(self) -> None:
-        pass
+        return None
 
     async def respond_without_state_change(
         self, request: service.UDSRequest

--- a/src/gallia/transports/_ctypes_vector_xl_wrapper.py
+++ b/src/gallia/transports/_ctypes_vector_xl_wrapper.py
@@ -22,8 +22,8 @@ INFINITE: int
 try:
     # Try builtin Python 3 Windows API
     from _winapi import WaitForSingleObject
-except ImportError:
-    raise RuntimeError("platform does not provide WaitForSingleObject")
+except ImportError as e:
+    raise RuntimeError("platform does not provide WaitForSingleObject") from e
 
 
 class FlexRayCtypesBackend:

--- a/src/gallia/transports/doip.py
+++ b/src/gallia/transports/doip.py
@@ -973,7 +973,7 @@ class DoIPTransport(BaseTransport, scheme="doip"):
             # BrokenPipeError but instead ignore it here and let upper layers handle
             # missing responses
             logger.debug("DoIP message was ACKed with TargetUnreachable")
-            raise TimeoutError
+            raise TimeoutError from None
 
         return len(data)
 


### PR DESCRIPTION
- **linter: Enable bugbear lints**
- **fix: Address all ruff issues found by enabling bugbear**

```
$ ruff check
B023 Function definition does not bind loop variable `max_lines`
    --> src/gallia/cli/cursed_hr.py:1041:32
     |
1039 |                 nonlocal display_entries
1040 |
1041 |                 for _ in range(max_lines - 1):
     |                                ^^^^^^^^^
1042 |                     old_entry_start = entry_start
1043 |                     old_line_start = line_start
     |

B023 Function definition does not bind loop variable `display_entries`
    --> src/gallia/cli/cursed_hr.py:1061:20
     |
1059 |                 nonlocal line_start
1060 |
1061 |                 if display_entries[0].entry_line_number == 0:
     |                    ^^^^^^^^^^^^^^^
1062 |                     if entry_start > 0:
1063 |                         entry_start = max(0, entry_start - 1)
     |

B027 `AsyncScript.setup` is an empty method in an abstract base class, but has no abstract decorator
   --> src/gallia/command/base.py:129:5
    |
127 |         self.log_file_handlers = []
128 |
129 |     async def setup(self) -> None: ...
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
130 |
131 |     @abstractmethod
    |

B027 `AsyncScript.teardown` is an empty method in an abstract base class, but has no abstract decorator
   --> src/gallia/command/base.py:134:5
    |
132 |     async def main(self) -> None: ...
133 |
134 |     async def teardown(self) -> None: ...
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
135 |
136 |     async def run(self) -> int:
    |

B011 Do not `assert False` (`python -O` removes these calls), raise `AssertionError()`
   --> src/gallia/commands/script/vecu.py:102:28
    |
100 |                     transport = UnixUDSServerTransport(server, target)
101 |                 case _:
102 |                     assert False
    |                            ^^^^^
103 |
104 |         if sys.platform.startswith("win32"):
    |
help: Replace `assert False`

B011 Do not `assert False` (`python -O` removes these calls), raise `AssertionError()`
   --> src/gallia/commands/script/vecu.py:109:28
    |
107 |                     transport = TCPUDSServerTransport(server, target)
108 |                 case _:
109 |                     assert False
    |                            ^^^^^
110 |
111 |         try:
    |
help: Replace `assert False`

B904 Within an `except` clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
   --> src/gallia/plugins/plugin.py:119:17
    |
117 |                 _merge_command_trees(cmd, value)
118 |             except ValueError as e:
119 |                 raise ValueError(f"{key} {str(e)}")
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
120 |         else:
121 |             raise ValueError(f"{key} ]: There already exists a leaf command")
    |

B905 `zip()` without an explicit `strict=` parameter
    --> src/gallia/services/uds/core/service.py:1240:45
     |
1238 |         pdu = pack("!B", self.RESPONSE_SERVICE_ID)
1239 |
1240 |         for data_identifier, data_record in zip(self.data_identifiers, self.data_records):
     |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
1241 |             pdu = pdu + to_bytes(data_identifier, 2) + data_record
     |
help: Add explicit value for parameter `strict=`

B905 `zip()` without an explicit `strict=` parameter
    --> src/gallia/services/uds/core/service.py:1270:40
     |
1268 |             return all(
1269 |                 req_id == resp_id
1270 |                 for req_id, resp_id in zip(request.data_identifiers, self.data_identifiers)
     |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
1271 |             )
     |
help: Add explicit value for parameter `strict=`

B905 `zip()` without an explicit `strict=` parameter
    --> src/gallia/services/uds/core/service.py:1630:84
     |
1628 |           )
1629 |
1630 |           for source_data_identifier, position_in_source_data_record, memory_size in zip(
     |  ____________________________________________________________________________________^
1631 | |             self.source_data_identifiers, self.positions_in_source_data_record, self.memory_sizes
1632 | |         ):
     | |_________^
1633 |               pdu = (
1634 |                   pdu
     |
help: Add explicit value for parameter `strict=`

B905 `zip()` without an explicit `strict=` parameter
    --> src/gallia/services/uds/core/service.py:1733:30
     |
1731 |         # In case the address_and_length_format_identifier is None, this calculates it based on the longest address and size
1732 |         # Otherwise it checks for all addresses and size if they can be represented with its length constraints.
1733 |         for address, size in zip(self.memory_addresses, self.memory_sizes):
     |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
1734 |             computed_address_and_length_format_identifier, _, _ = uds_memory_parameters(
1735 |                 address, size, address_and_length_format_identifier
     |
help: Add explicit value for parameter `strict=`

B905 `zip()` without an explicit `strict=` parameter
    --> src/gallia/services/uds/core/service.py:1777:44
     |
1775 |         )
1776 |
1777 |         for memory_address, memory_size in zip(self.memory_addresses, self.memory_sizes):
     |                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
1778 |             _, address, size = uds_memory_parameters(
1779 |                 memory_address, memory_size, self.address_and_length_format_identifier
     |
help: Add explicit value for parameter `strict=`

B007 Loop control variable `dtc_ext_data_record` not used within loop body
    --> src/gallia/services/uds/core/service.py:2744:41
     |
2742 |             self.dtc_and_status_record = dtc_and_status_record
2743 |
2744 |         for dtc_ext_data_record_number, dtc_ext_data_record in dtc_ext_data_records.items():
     |                                         ^^^^^^^^^^^^^^^^^^^
2745 |             check_range(dtc_ext_data_record_number, "dtc_ext_data_record_number", 0, 0xFD)
     |
help: Rename unused `dtc_ext_data_record` to `_dtc_ext_data_record`

B904 Within an `except` clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
   --> src/gallia/services/uds/helpers.py:106:17
    |
104 |             # RequestResponseMismatch takes priority over MalformedResponse
105 |             if len(pdu) >= 3 and pdu[2] != request.service_id:
106 |                 raise RequestResponseMismatch(request, response)
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
107 |         else:
108 |             response = service.RawPositiveResponse(pdu)
    |

B904 Within an `except` clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
   --> src/gallia/services/uds/helpers.py:111:17
    |
109 |             # RequestResponseMismatch takes priority over MalformedResponse
110 |             if response.service_id != request.service_id:
111 |                 raise RequestResponseMismatch(request, response)
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
112 |
113 |         raise MalformedResponse(request, response, str(e)) from e
    |

B027 `UDSServer.setup` is an empty method in an abstract base class, but has no abstract decorator
   --> src/gallia/services/uds/server.py:222:5
    |
220 |               self.state.session = 1
221 |
222 | /     async def setup(self) -> None:
223 | |         pass
    | |____________^
224 |
225 |       async def teardown(self) -> None:
    |

B027 `UDSServer.teardown` is an empty method in an abstract base class, but has no abstract decorator
   --> src/gallia/services/uds/server.py:225:5
    |
223 |           pass
224 |
225 | /     async def teardown(self) -> None:
226 | |         pass
    | |____________^
227 |
228 |       async def respond_without_state_change(
    |

B904 Within an `except` clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
  --> src/gallia/transports/_ctypes_vector_xl_wrapper.py:26:5
   |
24 |     from _winapi import WaitForSingleObject
25 | except ImportError:
26 |     raise RuntimeError("platform does not provide WaitForSingleObject")
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |

B904 Within an `except` clause, raise exceptions with `raise ... from err` or `raise ... from None` to distinguish them from errors in exception handling
   --> src/gallia/transports/doip.py:976:13
    |
974 |             # missing responses
975 |             logger.debug("DoIP message was ACKed with TargetUnreachable")
976 |             raise TimeoutError
    |             ^^^^^^^^^^^^^^^^^^
977 |
978 |         return len(data)
    |

Found 19 errors.
No fixes available (8 hidden fixes can be enabled with the `--unsafe-fixes` option).
```