### PR TITLE
refactor(UDSScanner): Remove redundant transport reference

### DIFF
--- a/src/gallia/command/base.py
+++ b/src/gallia/command/base.py
@@ -78,7 +78,6 @@ class AsyncScriptConfig(GalliaBaseModel, cli_group="generic", config_section="ga
         None,
         description="Base directory for artifacts. Required to save artifacts such as logs.",
         metavar="DIR",
-        config_section="gallia",
     )
 
 

--- a/src/gallia/command/config.py
+++ b/src/gallia/command/config.py
@@ -337,7 +337,7 @@ class GalliaBaseModel(BaseCommand, ABC):
                     info.config_section = config_section
 
                 # Add config to registry
-                if info.config_section is not None:
+                if info.config_section is not None and info.hidden is False:
                     config_attribute = (
                         f"{info.config_section}.{attribute}"
                         if info.config_section != ""


### PR DESCRIPTION
After the class merge, there now is no more need to maintain a transport
reference on the `UDSScanner` object level. On the contrary, it
complicates things and might lead to confusion.

Closes https://github.com/Fraunhofer-AISEC/gallia/issues/808