### PR TITLE
feat(sa_dump_seeds): Improved handling of reset and sleep

### DIFF
--- a/src/gallia/commands/scan/uds/sa_dump_seeds.py
+++ b/src/gallia/commands/scan/uds/sa_dump_seeds.py
@@ -57,10 +57,10 @@ class SASeedsDumperConfig(UDSScannerConfig):
 
 
 class SASeedsDumper(UDSScanner):
-    """This scanner tries to enable ProgrammingSession and dump seeds for 12h."""
+    """This scanner tries to dump SecurityAccess seeds."""
 
     CONFIG_TYPE = SASeedsDumperConfig
-    SHORT_HELP = "dump security access seeds"
+    SHORT_HELP = "dump SecurityAccess seeds"
 
     attempt_reset: bool = False
     is_key_length_determined: bool = False
@@ -166,6 +166,18 @@ class SASeedsDumper(UDSScanner):
             # Start with length 1 in automatic search
             self.key_length = 1
 
+            # When resets are only triggered on demand (self.config.reset == 0), their impact on the
+            # time required for key length determination is usually minimal. Thus, the following
+            # notice should only be printed if resets are explicitly forced every n-th attempt by
+            # the user.
+            if (self.config.reset is not None) and (self.config.reset > 0):
+                logger.notice(
+                    "You combined '--reset N' with '--send-zero-key' without providing a key "
+                    "length. Automatically determining the key size expected by the ECU in this "
+                    "setting might be very slow. Consider not forcing resets or set the key length "
+                    "explicitly if it is known."
+                )
+
         while duration <= 0 or time.time() - start_time < duration:
             # Print information about current dump speed every `interval` seconds.
             # As request/response times can jitter a few seconds, we 'arm' the print
@@ -174,9 +186,15 @@ class SASeedsDumper(UDSScanner):
             i = int(time.time() - start_time) % interval
             if i >= interval // 2:
                 print_speed = True
-            elif i < interval // 2 and print_speed is True:
+            # Print dump speed only when actually dumping seeds, not while determining the key size,
+            # as this will lead to confusing output.
+            elif i < interval // 2 and print_speed is True and self.is_key_length_determined:
                 self.log_size(seeds_file, time.time() - start_time)
                 print_speed = False
+
+            if self.config.sleep is not None:
+                logger.info(f"Sleeping for {self.config.sleep} seconds between seed requests…")
+                await asyncio.sleep(self.config.sleep)
 
             if self.config.reset is not None:
                 if (self.config.reset == 0 and self.attempt_reset) or (
@@ -239,10 +257,6 @@ class SASeedsDumper(UDSScanner):
                 except Exception as e:
                     logger.critical(f"Error while sending key: {g_repr(e)}")
                     sys.exit(1)
-
-            if self.config.sleep is not None:
-                logger.info(f"Sleeping for {self.config.sleep} seconds between seed requests…")
-                await asyncio.sleep(self.config.sleep)
 
         file.close()
         self.log_size(seeds_file, time.time() - start_time)


### PR DESCRIPTION
- Prints a note when resets slow down automatic key-length detection
- Improves sleep between consecutive seed requests in cases where the main loop is `continue`-ed early, before the current `sleep` is even reached.
- Minor corrections in scanner description