### PR TITLE
chore: Try to make dependabot less verbose

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,16 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
This should instruct dependabot to create only one merge request for all dependencies (per ecosystem, but github actions are not so frequently updated). Then we can easily hit the squash button prior to merge.