### PR TITLE
fix(cli): Check default types at runtime

### DIFF
--- a/src/gallia/command/base.py
+++ b/src/gallia/command/base.py
@@ -56,7 +56,7 @@ logger = get_logger(__name__)
 
 
 class AsyncScriptConfig(GalliaBaseModel, cli_group="generic", config_section="gallia"):
-    model_config = ConfigDict(arbitrary_types_allowed=True)
+    model_config = ConfigDict(arbitrary_types_allowed=True, validate_default=True)
 
     verbose: int = Field(
         0,


### PR DESCRIPTION
Without this setting, it is never checked whether the default value of fields actually matches the given type hint, which can result in unexpected behavior.

Unfortunately, this is not picked up by the static type checkers, so it might silently introduce error messages at runtime.