### PR TITLE
fix(db): Adjust run_stats view to changed run_meta columns

### DIFF
--- a/src/gallia/db/handler.py
+++ b/src/gallia/db/handler.py
@@ -111,7 +111,7 @@ SELECT
   ru.id AS run,
   ecu.name AS ECU,
   rm.script,
-  rm.arguments,
+  rm.config,
   strftime('%Y-%m-%d %H:%M:%f', rm.start_time, 'unixepoch', 'localtime') AS start,
   strftime('%Y-%m-%d %H:%M:%f', rm.end_time, 'unixepoch', 'localtime') AS end,
   cast((CASE WHEN end_time IS NULL THEN strftime('%s','now') ELSE end_time END - start_time) / 86400 AS int) || ' ' ||


### PR DESCRIPTION
In https://github.com/Fraunhofer-AISEC/gallia/commit/600676ec5f9f43f714338684ea7f5931d5de0703 the column of run_meta changed from arguments to config. This was not updated for the view run_stats, leading to an error when attempting to query the view. Surprisingly (at least for me), the create statement itself does not check the correctness of the statement, and the error remained undetected.

Note, that this does not automatically fix existing databases.
For this, the view needs to be dropped (`drop view run_stats;`) and the view created anew afterwards, e.g. by running any command that accesses the database.