### PR TITLE
fix(cursed-hr): use wcwidth to process unicode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "tabulate >=0.9",
     "zstandard >=0.19; python_version < '3.14'",
     "more-itertools >=10.3.0,<11.0.0; sys_platform == 'win32' and python_version < '3.12'",
+    "wcwidth>=0.3.0",
 ]
 
 [project.entry-points."gallia_plugins"]

--- a/src/gallia/cli/cursed_hr.py
+++ b/src/gallia/cli/cursed_hr.py
@@ -18,11 +18,11 @@ from copy import deepcopy
 from dataclasses import dataclass
 from datetime import datetime
 from enum import IntEnum, unique
-from math import ceil
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, BinaryIO
 
 import platformdirs
+from wcwidth import wrap
 
 if sys.version_info < (3, 14):
     import zstandard as zstd
@@ -525,11 +525,8 @@ class CursedHR:
         for line in user_defined_lines:
             if len(line) == 0:
                 terminal_width_defined_lines.append("")
-
-            for i in range(ceil(len(line) / residual_width)):
-                terminal_width_defined_lines.append(
-                    line[i * residual_width : (i + 1) * residual_width]
-                )
+            else:
+                terminal_width_defined_lines += wrap(line, residual_width)
 
         result = [
             DisplayEntry(

--- a/uv.lock
+++ b/uv.lock
@@ -304,6 +304,7 @@ dependencies = [
     { name = "platformdirs" },
     { name = "pydantic" },
     { name = "tabulate" },
+    { name = "wcwidth" },
     { name = "zstandard", marker = "python_full_version < '3.14'" },
 ]
 
@@ -346,6 +347,7 @@ requires-dist = [
     { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.1a29" },
     { name = "types-boltons", marker = "extra == 'dev'", specifier = ">=25.0.0.20250919" },
     { name = "types-tabulate", marker = "extra == 'dev'", specifier = ">=0.9,<0.10" },
+    { name = "wcwidth", specifier = ">=0.3.0" },
     { name = "zstandard", marker = "python_full_version < '3.14'", specifier = ">=0.19" },
 ]
 provides-extras = ["dev"]
@@ -1189,6 +1191,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/74/cf/209d90506b7d6c5873f82c5a226d7aad1a1da153364e9ebf61eff0740c33/ujson-5.11.0-pp311-pypy311_pp73-manylinux_2_24_i686.manylinux_2_28_i686.whl", hash = "sha256:86baf341d90b566d61a394869ce77188cc8668f76d7bb2c311d77a00f4bdf844", size = 56584, upload-time = "2025-08-20T11:56:52.89Z" },
     { url = "https://files.pythonhosted.org/packages/e9/97/bd939bb76943cb0e1d2b692d7e68629f51c711ef60425fa5bb6968037ecd/ujson-5.11.0-pp311-pypy311_pp73-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4598bf3965fc1a936bd84034312bcbe00ba87880ef1ee33e33c1e88f2c398b49", size = 51588, upload-time = "2025-08-20T11:56:54.054Z" },
     { url = "https://files.pythonhosted.org/packages/52/5b/8c5e33228f7f83f05719964db59f3f9f276d272dc43752fa3bbf0df53e7b/ujson-5.11.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:416389ec19ef5f2013592f791486bef712ebce0cd59299bf9df1ba40bb2f6e04", size = 43835, upload-time = "2025-08-20T11:56:55.237Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/62/a7c072fbfefb2980a00f99ca994279cb9ecf310cb2e6b2a4d2a28fe192b3/wcwidth-0.5.3.tar.gz", hash = "sha256:53123b7af053c74e9fe2e92ac810301f6139e64379031f7124574212fb3b4091", size = 157587, upload-time = "2026-01-31T03:52:10.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/c1/d73f12f8cdb1891334a2ccf7389eed244d3941e74d80dd220badb937f3fb/wcwidth-0.5.3-py3-none-any.whl", hash = "sha256:d584eff31cd4753e1e5ff6c12e1edfdb324c995713f75d26c29807bb84bf649e", size = 92981, upload-time = "2026-01-31T03:52:09.14Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Currently cursed-hr fails when parsing unicode sequences (depending on window size).
This PR fixes it by using the wcwidth library's wrap function.
At least wcwidth 0.3 is required for the wrap function.