### PR TITLE
fix(cursed-hr): Fix crash on page up

### DIFF
--- a/src/gallia/cli/cursed_hr.py
+++ b/src/gallia/cli/cursed_hr.py
@@ -1044,6 +1044,7 @@ class CursedHR:
                             entry_start = max(0, display_entries[0].penlog_entry_number - 1)
                             line_start = -1
                     else:
+                        entry_start = display_entries[0].penlog_entry_number
                         line_start = display_entries[0].entry_line_number - 1
 
                     if old_entry_start == entry_start and old_line_start == line_start:


### PR DESCRIPTION
There was a bug when using page up to scroll through a logfile in certain conditions.
This fixes it.