### PR TITLE
chore(config): Rename `Idempotent` and make doc clearer

### DIFF
--- a/src/gallia/cli/netzteil.py
+++ b/src/gallia/cli/netzteil.py
@@ -9,7 +9,7 @@ from pydantic import field_serializer, model_validator
 from gallia.cli.gallia import parse_and_run
 from gallia.command import AsyncScript
 from gallia.command.base import AsyncScriptConfig
-from gallia.command.config import Field, Idempotent
+from gallia.command.config import Field, InitializeIdempotent
 from gallia.command.uds import UDSScannerConfig
 from gallia.power_supply import power_supply_drivers
 from gallia.power_supply.base import BasePowerSupplyDriver
@@ -19,7 +19,7 @@ from gallia.utils import strtobool
 
 
 class CLIConfig(AsyncScriptConfig):
-    power_supply: Idempotent[PowerSupplyURI] = Field(
+    power_supply: InitializeIdempotent[PowerSupplyURI] = Field(
         description="URI specifying the location of the powersupply",
         metavar="URI",
         short="t",

--- a/src/gallia/command/base.py
+++ b/src/gallia/command/base.py
@@ -56,7 +56,9 @@ logger = get_logger(__name__)
 
 
 class AsyncScriptConfig(GalliaBaseModel, cli_group="generic", config_section="gallia"):
-    model_config = ConfigDict(arbitrary_types_allowed=True, validate_default=True)
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True, validate_default=True, validate_assignment=True
+    )
 
     verbose: int = Field(
         0,

--- a/src/gallia/command/config.py
+++ b/src/gallia/command/config.py
@@ -133,7 +133,7 @@ def auto_enum(x: str, enum_type: type[EnumType]) -> EnumType:
 
 
 if TYPE_CHECKING:
-    Idempotent: TypeAlias = Annotated[T, ""]
+    InitializeIdempotent: TypeAlias = Annotated[T, ""]
     EnumArg: TypeAlias = Annotated[EnumType, ""]
     AutoLiteral: TypeAlias = Annotated[LiteralType, ""]
 else:
@@ -145,15 +145,15 @@ else:
         def __getitem__(self, cls: type[T]) -> type[T]:
             return self.function(cls)
 
-    Idempotent = _TrickType(
+    InitializeIdempotent = _TrickType(
         lambda cls: Annotated[cls, BeforeValidator(lambda x: x if isinstance(x, cls) else cls(x))]
     )
     """
-    Wrapper for fields of types which can be instantiated by a certain value, but not by an instance of its own type.
+    Wrapper for fields of arbitrary types which are not automatically instantiated by pydantic.
 
-    This way, it is possible to fill the corresponding parameter of the model with both the value as well as an already instantiated object of that class.
+    It is idempotent, such that it is possible to fill the corresponding parameter of the model with both any value as well as an already instantiated object of that class.
 
-    Usage: x: Idempotent[SomeClass] = ...
+    Usage: x: InitializeIdempotent[SomeClass] = ...
     """
 
     EnumArg = _TrickType(

--- a/src/gallia/command/uds.py
+++ b/src/gallia/command/uds.py
@@ -10,7 +10,7 @@ from typing import Any, Self
 from pydantic import field_serializer, field_validator, model_validator
 
 from gallia.command.base import AsyncScript, AsyncScriptConfig, FileNames
-from gallia.command.config import Field, Idempotent
+from gallia.command.config import Field, InitializeIdempotent
 from gallia.log import get_logger
 from gallia.plugins.plugin import load_ecu, load_ecus, load_transport
 from gallia.power_supply import PowerSupply
@@ -68,10 +68,10 @@ class UDSScannerConfig(AsyncScriptConfig, cli_group="uds", config_section="galli
     dumpcap: bool = Field(
         sys.platform.startswith("linux"), description="Enable/Disable creating a pcap file"
     )
-    target: Idempotent[TargetURI] = Field(
+    target: InitializeIdempotent[TargetURI] = Field(
         description="URI that describes the target", metavar="TARGET"
     )
-    power_supply: Idempotent[PowerSupplyURI] | None = Field(
+    power_supply: InitializeIdempotent[PowerSupplyURI] | None = Field(
         None,
         description="URI specifying the location of the relevant opennetzteil server",
         metavar="URI",

--- a/src/gallia/command/uds.py
+++ b/src/gallia/command/uds.py
@@ -178,7 +178,7 @@ class UDSScanner(AsyncScript, ABC):
                 )
 
         # Check and replace target string aliases (requires DB!)
-        if self.db_handler is not None and len(self.config.target.url.scheme) == 0:
+        if self.db_handler is not None and len(self.config.target.scheme) == 0:
             logger.debug(
                 f"Target string {self.config.target.raw} has no scheme, checking if it is an alias"
             )

--- a/src/gallia/commands/primitive/generic/pdu.py
+++ b/src/gallia/commands/primitive/generic/pdu.py
@@ -9,7 +9,7 @@ from pydantic import field_serializer
 
 from gallia.command import AsyncScript
 from gallia.command.base import AsyncScriptConfig
-from gallia.command.config import Field, HexBytes, Idempotent
+from gallia.command.config import Field, HexBytes, InitializeIdempotent
 from gallia.command.uds import UDSScannerConfig
 from gallia.plugins.plugin import load_transport
 from gallia.transports.base import TargetURI
@@ -23,7 +23,7 @@ class GenericPDUPrimitiveConfig(AsyncScriptConfig):
         config_section=UDSScannerConfig._config_section,
     )
     pdu: HexBytes = Field(description="raw pdu to send", positional=True)
-    target: Idempotent[TargetURI] = Field(
+    target: InitializeIdempotent[TargetURI] = Field(
         description="URI that describes the target", metavar="TARGET"
     )
 

--- a/src/gallia/commands/script/vecu.py
+++ b/src/gallia/commands/script/vecu.py
@@ -12,7 +12,7 @@ from pydantic import field_serializer, model_validator
 
 from gallia.command import AsyncScript
 from gallia.command.base import AsyncScriptConfig
-from gallia.command.config import Field, Idempotent
+from gallia.command.config import Field, InitializeIdempotent
 from gallia.log import get_logger
 from gallia.services.uds.server import (
     DBUDSServer,
@@ -27,7 +27,7 @@ logger = get_logger(__name__)
 
 
 class VirtualECUConfig(AsyncScriptConfig):
-    target: Idempotent[TargetURI] = Field(positional=True)
+    target: InitializeIdempotent[TargetURI] = Field(positional=True)
 
     @field_serializer("target")
     def serialize_target_uri(self, target_uri: TargetURI | None) -> Any:

--- a/src/gallia/db/handler.py
+++ b/src/gallia/db/handler.py
@@ -470,3 +470,15 @@ class DBHandler:
 
         result: list[int] = json.loads(row[0])
         return result
+
+    async def lookup_target_names(self, target_name: str) -> list[str]:
+        assert self.connection is not None, "Not connected to the database"
+
+        query = """
+            SELECT url
+            FROM address
+            LEFT JOIN ecu ON address.ecu = ecu.id
+            WHERE name LIKE ?
+            """
+        resp = await self.connection.execute_fetchall(query, (f"%{target_name}%",))
+        return [x[0] for x in resp]

--- a/src/gallia/transports/base.py
+++ b/src/gallia/transports/base.py
@@ -13,7 +13,6 @@ from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 from gallia.dumpcap import Dumpcap
 from gallia.log import get_logger
 from gallia.net import join_host_port
-from gallia.transports.schemes import TransportScheme
 
 logger = get_logger(__name__)
 
@@ -48,9 +47,9 @@ class TargetURI:
         return cls(urlunparse((scheme, netloc, "", "", urlencode(args), "")))
 
     @property
-    def scheme(self) -> TransportScheme:
+    def scheme(self) -> str:
         """The URI scheme"""
-        return TransportScheme(self.url.scheme)
+        return self.url.scheme
 
     @property
     def hostname(self) -> str | None:


### PR DESCRIPTION
Its main purpose is to instantiate arbitrary types which otherwise would be ignored by pydantic. The idempotent property is only secondary.