### PR TITLE
fix(cli parsing): interpret input for int literal when using AutoLiteral

### DIFF
--- a/src/gallia/command/config.py
+++ b/src/gallia/command/config.py
@@ -180,6 +180,8 @@ else:
                 mapping[arg.name] = arg
             elif isinstance(arg, bytes):
                 mapping[binascii.hexlify(arg)] = arg
+            else:
+                mapping[arg] = arg
 
         def try_auto_literal(value: Any):
             if value in args:


### PR DESCRIPTION
according to the description and the function below, this was already planned, but it was forgotten to add the value to the mapping for int literals specifically or as a default, as decided in this PR.