### PR TITLE
feat(config): Add `create_template` method to `GalliaBaseModel`

### DIFF
--- a/src/gallia/cli/gallia.py
+++ b/src/gallia/cli/gallia.py
@@ -4,19 +4,16 @@
 
 import argparse
 import asyncio
-import json
 import os
 import sys
 from collections.abc import Callable, Mapping, MutableMapping, Sequence
 from importlib.metadata import version as meta_version
 from pprint import pprint
-from textwrap import wrap
 from types import UnionType
 from typing import Any, Never
 
 import argcomplete
 from pydantic import Field, create_model
-from pydantic_core import PydanticUndefined
 
 from gallia import exitcodes
 from gallia.command import AsyncScript
@@ -282,45 +279,7 @@ def template() -> None:
     """
     Prints a template config with default according to the programmatic defaults.
     """
-    groups: dict[str, dict[str, tuple[str, Any]]] = {}
-
-    for key, value in GalliaBaseModel.registry().items():
-        tmp = key.split(".")
-        group = ".".join(tmp[:-1])
-        attribute = tmp[-1]
-
-        if group not in groups:
-            groups[group] = {}
-
-        groups[group][attribute] = value
-
-    output = ""
-
-    for group in sorted(groups):
-        if group != "":
-            output += f"[{group}]\n"
-
-        for attribute in sorted(groups[group]):
-            description, default_value = groups[group][attribute]
-
-            output += "\n".join(wrap(f"# {description}\n", subsequent_indent="# ")) + "\n"
-
-            # Heuristic TOML dump
-            if default_value is not None and default_value is not PydanticUndefined:
-                try:
-                    default_repr = json.dumps(default_value)
-                except TypeError:
-                    default_repr = json.dumps(str(default_value))
-
-                output += f"{attribute} = {default_repr}\n"
-            else:
-                output += f"# {attribute} = ...\n"
-
-            output += "\n"
-
-        output += "\n"
-
-    print(output.strip())
+    print(GalliaBaseModel.create_template() + "\n")
 
 
 def main() -> None:
@@ -331,7 +290,7 @@ def main() -> None:
             "--version": (version, "show version and exit"),
             "--show-plugins": (show_plugins, "show registered plugins"),
             "--show-config": (show_config, "show loaded config"),
-            "--template": (template, "generate a annotated config template"),
+            "--template": (template, "generate an annotated config template"),
         },
         show_help_on_zero_args=True,
     )

--- a/src/gallia/cli/gallia.py
+++ b/src/gallia/cli/gallia.py
@@ -33,8 +33,6 @@ def _create_parser_from_command(
     command: type[AsyncScript], config: Config, extra_defaults: defaults, model_counter: int = 0
 ) -> tuple[type[PydanticBaseCommand], defaults, int]:
     config_attributes = command.CONFIG_TYPE.attributes_from_config(config)
-    env_attributes = command.CONFIG_TYPE.attributes_from_env()
-    config_attributes.update(env_attributes)
 
     # it is necessary to create a submodel, because several commands can use the same config
     # (e.g. of their base class if no additional arguments are required)

--- a/src/gallia/command/config.py
+++ b/src/gallia/command/config.py
@@ -3,13 +3,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import binascii
-import os
+import json
 import tomllib
 import typing
 from abc import ABC
 from collections.abc import Callable
 from enum import Enum
 from pathlib import Path
+from textwrap import wrap
 from typing import (
     TYPE_CHECKING,
     Annotated,
@@ -372,9 +373,57 @@ class GalliaBaseModel(BaseCommand, ABC):
                         info.default,
                     )
 
-    @staticmethod
-    def registry() -> dict[str, tuple[str, Any]]:
-        return GalliaBaseModel.__config_registry
+    @classmethod
+    def create_template(cls, default_values: Config | None = None) -> str:
+        """
+        Returns a string which can be loaded as config file.
+        If `default_values` is given, defaults are not loaded from the field definitions, but from this object instead.
+        """
+        groups: dict[str, dict[str, tuple[str, Any]]] = {}
+
+        for key, value in cls.__config_registry.items():
+            # If given, load value from config instead
+            if default_values is not None and default_values.get_value(key) is not None:
+                final_value = (value[0], default_values.get_value(key))
+            else:
+                final_value = value
+
+            tmp = key.split(".")
+            group = ".".join(tmp[:-1])
+            attribute = tmp[-1]
+
+            if group not in groups:
+                groups[group] = {}
+
+            groups[group][attribute] = final_value
+
+        output = ""
+
+        for group in sorted(groups):
+            if group != "":
+                output += f"[{group}]\n"
+
+            for attribute in sorted(groups[group]):
+                description, value = groups[group][attribute]
+
+                output += "\n".join(wrap(f"# {description}\n", subsequent_indent="# ")) + "\n"
+
+                # Heuristic TOML dump
+                if value is not None and value is not PydanticUndefined:
+                    try:
+                        str_value = json.dumps(value)
+                    except TypeError:
+                        str_value = json.dumps(str(value))
+
+                    output += f"{attribute} = {str_value}\n"
+                else:
+                    output += f"# {attribute} = ...\n"
+
+                output += "\n"
+
+            output += "\n"
+
+        return output.strip()
 
     @classmethod
     def attributes_from_toml(cls, path: Path) -> dict[str, Any]:

--- a/src/gallia/command/config.py
+++ b/src/gallia/command/config.py
@@ -445,17 +445,3 @@ class GalliaBaseModel(BaseCommand, ABC):
                         result[name] = (f"{source} ({info.config_section}:{name})", value)
 
         return result
-
-    @classmethod
-    def attributes_from_env(cls) -> dict[str, Any]:
-        result = {}
-
-        if (original_infos := cls._original_field_infos) is not None:
-            for name, info in original_infos.items():
-                if isinstance(info, ConfigArgFieldInfo):
-                    config_attribute = f"GALLIA_{name.upper()}"
-
-                    if (value := os.getenv(config_attribute)) is not None:
-                        result[name] = (f"environment variable ({config_attribute})", value)
-
-        return result

--- a/src/gallia/command/config.py
+++ b/src/gallia/command/config.py
@@ -438,7 +438,7 @@ class GalliaBaseModel(BaseCommand, ABC):
             for name, info in original_infos.items():
                 if isinstance(info, ConfigArgFieldInfo):
                     config_attribute = (
-                        f"{info.config_section}.{name}" if info.config_section != "" else name
+                        f"{info.config_section}.{name}" if info.config_section else name
                     )
 
                     if (value := config.get_value(config_attribute)) is not None:


### PR DESCRIPTION
This method generates a string which can be loaded as config value.

When called on an "empty" `GalliaBaseModel`, this string represents a template config, and if called on an instantiated config with custom values, those values are represented in the config file.