### PR TITLE
fix: urlunsplit() only takes a five-item iterable

### DIFF
--- a/src/gallia/transports/base.py
+++ b/src/gallia/transports/base.py
@@ -44,7 +44,7 @@ class TargetURI:
         The ``args`` dict is used for the query string.
         """
         netloc = host if port is None else join_host_port(host, port)
-        return cls(urlunsplit((scheme, netloc, "", "", urlencode(args), "")))
+        return cls(urlunsplit((scheme, netloc, "", urlencode(args), "")))
 
     @property
     def scheme(self) -> str:


### PR DESCRIPTION
The migration from `urlunparse()` to `urlunsplit()` introduced a bug due to the latter only taking a five-item iterable as argument, in contrast to the six-item iterable used before. The *params* attribute that used to be at index 3 is no longer present.