### PR TITLE
fix(ruff): Explicitely disable previously not existing rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,7 @@ ignore = [
     "PLR0912",  # too many branches
     "PLR0913",  # too many arguments to function call
     "PLR0915",  # too many statements
+    "PLR0917",  # too many positional arguments
     "PLC1901",  # empty string is falsey
     "TD001",    # Invalid TODO tag: {tag}
     "TD002",    # Missing author in TODO; try: # TODO(<author_name>): ... or # TODO @<author_name>: ...


### PR DESCRIPTION
PLR0917 was introduced with ruff 0.16 and flags 25 errors. Since we already ignore the broader PLR0913  "too many arguments to function call" we should also ignore PLR0917 "too many positional arguments".