### PR TITLE
fix(ecu): Correctly use retries in `check_and_set_session`

### DIFF
--- a/src/gallia/commands/scan/uds/identifiers.py
+++ b/src/gallia/commands/scan/uds/identifiers.py
@@ -145,7 +145,7 @@ class ScanIdentifiers(UDSScanner):
                 and (DID % self.config.check_session == 0)
             ):
                 # Check session and try to recover from wrong session (max 3 times), else skip session
-                if not await self.ecu.check_and_set_session(session, retries=3):
+                if not await self.ecu.check_and_set_session(session):
                     logger.error(
                         f"Aborting scan on session {g_repr(session)}; current DID was {g_repr(DID)}"
                     )

--- a/src/gallia/services/uds/ecu.py
+++ b/src/gallia/services/uds/ecu.py
@@ -151,7 +151,7 @@ class ECU(UDSClient):
     async def check_and_set_session(
         self,
         expected_session: int,
-        retries: int = 3,
+        retries: int = 2,
     ) -> bool:
         """check_and_set_session() reads the current session and (re)tries to set
         the session to the expected session if they do not match.
@@ -184,7 +184,7 @@ class ECU(UDSClient):
             )
 
             logger.info(
-                f"Switching to session {g_repr(expected_session)}; attempt {i + 1} of {retries}"
+                f"Switching to session {g_repr(expected_session)}; attempt {i + 1} of {1 + retries}"
             )
             resp = await self.set_session(expected_session)
 
@@ -210,7 +210,7 @@ class ECU(UDSClient):
                 return True
 
         logger.warning(
-            f"Failed to switch to session {g_repr(expected_session)} after {retries} attempts"
+            f"Failed to switch to session {g_repr(expected_session)} after {1 + retries} attempts"
         )
         return False
 


### PR DESCRIPTION
`check_and_set_session` is supposed to make 3 attempts to change to the expected session. Thus, only retry for 2 times and correctly log max. attempts.